### PR TITLE
Cache Make API calls and run scenarios concurrently

### DIFF
--- a/support_assistant/agents.py
+++ b/support_assistant/agents.py
@@ -1,0 +1,45 @@
+"""Utility functions for interacting with Make scenarios.
+
+This module caches heavy external API calls and provides utilities
+for executing scenarios concurrently.
+"""
+
+import asyncio
+from functools import lru_cache
+from typing import Iterable, List
+
+import config
+
+MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+
+
+@lru_cache(maxsize=128)
+def _connect_to_make(api_token: str, scenario_id: str) -> dict:
+    """Simulate triggering a Make scenario.
+
+    The real implementation should handle errors and perform an HTTP call.
+    """
+    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
+    # Example network call (disabled in this environment):
+    # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
+    # return response.json()
+    return {"status": "connected", "scenario": scenario_id}
+
+
+def connect_to_make(api_token: str, scenario_id: str) -> dict:
+    """Trigger a Make scenario, using cache if enabled."""
+    if config.ENABLE_CACHE:
+        return _connect_to_make(api_token, scenario_id)
+    # Bypass cache by calling the wrapped function directly
+    _connect_to_make.cache_clear()
+    return _connect_to_make.__wrapped__(api_token, scenario_id)
+
+
+async def run_scenarios(api_token: str, scenario_ids: Iterable[str]) -> List[dict]:
+    """Run multiple scenarios concurrently.
+
+    Each scenario is executed in a thread to avoid blocking the event loop.
+    """
+    loop = asyncio.get_running_loop()
+    tasks = [loop.run_in_executor(None, connect_to_make, api_token, sid) for sid in scenario_ids]
+    return await asyncio.gather(*tasks)

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,21 +1,11 @@
 from flask import Flask, request, render_template
-import requests
+import asyncio
+
+from agents import run_scenarios
 
 app = Flask(__name__)
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
-MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
-
-
-def connect_to_make(api_token: str, scenario_id: str) -> dict:
-    """Simulate triggering a Make scenario using the provided API token.
-    The real implementation should handle errors and actual API calls.
-    """
-    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
-    # Example request (commented out as this environment has no external access)
-    # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
-    # return response.json()
-    return {"status": "connected", "scenario": scenario_id}
 
 
 @app.route("/", methods=["GET"])
@@ -26,11 +16,16 @@ def index():
 @app.route("/install", methods=["POST"])
 def install():
     api_token = request.form.get("api_token")
-    scenario_id = request.form.get("scenario_id")
-    if not api_token or not scenario_id:
+    scenario_ids_raw = request.form.get("scenario_id")
+    if not api_token or not scenario_ids_raw:
         return "Missing credentials", 400
-    result = connect_to_make(api_token, scenario_id)
-    return f"Scenario {result['scenario']} triggered with status {result['status']}."
+    scenario_ids = [sid.strip() for sid in scenario_ids_raw.split(",")]
+    results = asyncio.run(run_scenarios(api_token, scenario_ids))
+    messages = [
+        f"Scenario {res['scenario']} triggered with status {res['status']}"
+        for res in results
+    ]
+    return "<br>".join(messages)
 
 
 if __name__ == "__main__":

--- a/support_assistant/config.py
+++ b/support_assistant/config.py
@@ -1,0 +1,4 @@
+import os
+
+# Toggle caching for heavy API calls. Set environment variable ENABLE_CACHE to 'false' to disable.
+ENABLE_CACHE = os.getenv("ENABLE_CACHE", "true").lower() == "true"


### PR DESCRIPTION
## Summary
- Add config toggle for caching heavy API calls
- Wrap Make scenario calls with lru_cache and provide async concurrency helper
- Update Flask app to run multiple scenarios in parallel using new utilities

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0849619dc8333bbb85acd7186aca6