### PR TITLE
feat: add centralized logging utilities with verbose option

### DIFF
--- a/logging_utils.py
+++ b/logging_utils.py
@@ -1,0 +1,23 @@
+import logging
+
+LOGGER_NAME = "graal_nexus"
+
+
+def setup_logging(level: int = logging.INFO) -> logging.Logger:
+    """Configure root logger and return the central logger.
+
+    Parameters
+    ----------
+    level: int
+        Logging level to configure. Defaults to INFO.
+    """
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    return logging.getLogger(LOGGER_NAME)
+
+
+def get_logger(name: str = LOGGER_NAME) -> logging.Logger:
+    """Retrieve a logger with the given name."""
+    return logging.getLogger(name)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,32 @@
+import argparse
+import logging
+
+from logging_utils import setup_logging, get_logger
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Graal Nexus AI runner")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug output",
+    )
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logger = setup_logging(level)
+
+    if args.verbose:
+        logger.debug("Verbose logging enabled")
+
+    logger.info("Scenario start")
+    try:
+        # Placeholder for scenario logic
+        logger.info("Scenario complete")
+    except Exception:  # noqa: BLE001
+        logger.exception("Scenario failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reusable logging utilities with configurable levels
- handle `--verbose` flag to enable debug logs
- report scenario lifecycle events through the central logger

## Testing
- `pytest`
- `python main.py --verbose`

------
https://chatgpt.com/codex/tasks/task_e_68a08497a5688333bebfe419f21fc428