### PR TITLE
Add agent and scenario orchestration framework

### DIFF
--- a/data/agents/Graal_Autopilot_Agent.json
+++ b/data/agents/Graal_Autopilot_Agent.json
@@ -1,0 +1,1 @@
+{"agent_name": "Graal Autopilot AI", "description": "Agent IA autonome pour Make - publication, ventes, alertes."}

--- a/data/agents/Graal_Oracle_Mystique.json
+++ b/data/agents/Graal_Oracle_Mystique.json
@@ -1,0 +1,1 @@
+{"agent_name": "Graal Oracle Mystique", "description": "Agent IA spirituel/mystique, réponses ésotériques et inspirantes."}

--- a/data/agents/Graal_Sales_Agent.json
+++ b/data/agents/Graal_Sales_Agent.json
@@ -1,0 +1,1 @@
+{"agent_name": "Graal Sales Agent V1", "description": "Agent IA spécialisé en ventes et conversion."}

--- a/data/scenarios/Graal_Alert_System.make.json
+++ b/data/scenarios/Graal_Alert_System.make.json
@@ -1,0 +1,1 @@
+{"scenario_name": "Graal Alert System", "goal": "Alerte WhatsApp/SMS, bilan journalier et actions IA."}

--- a/data/scenarios/Graal_Autopilot_Engine.make.json
+++ b/data/scenarios/Graal_Autopilot_Engine.make.json
@@ -1,0 +1,1 @@
+{"scenario_name": "Graal Autopilot Engine", "goal": "Automatisation complète de l’écosystème Graal Nexus."}

--- a/data/scenarios/Graal_Infinite_Reach.make.json
+++ b/data/scenarios/Graal_Infinite_Reach.make.json
@@ -1,0 +1,1 @@
+{"scenario_name": "Graal Infinite Reach", "goal": "Publication virale multi-niches en automatique."}

--- a/data/scenarios/Vitamenu_Auto_Sales.make.json
+++ b/data/scenarios/Vitamenu_Auto_Sales.make.json
@@ -1,0 +1,1 @@
+{"scenario_name": "Vitamenu Auto Sales", "goal": "Automatisation des ventes et tunnels marketing pour Vitamenu."}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from src import config
+from src.agents import Agent
+from src.scenarios import Scenario
+from src.scheduler import Scheduler
+
+
+def list_available(directory: Path) -> None:
+    for item in directory.glob("*.json"):
+        print(item.name)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Orchestrate agents and scenarios")
+    subparsers = parser.add_subparsers(dest="command")
+
+    list_parser = subparsers.add_parser("list", help="List available agents or scenarios")
+    list_parser.add_argument("target", choices=["agents", "scenarios"], help="What to list")
+
+    run_parser = subparsers.add_parser("run", help="Run a scenario with an agent")
+    run_parser.add_argument("agent", help="Agent JSON filename")
+    run_parser.add_argument("scenario", help="Scenario JSON filename")
+
+    args = parser.parse_args()
+
+    if args.command == "list":
+        if args.target == "agents":
+            list_available(config.AGENTS_DIR)
+        else:
+            list_available(config.SCENARIOS_DIR)
+    elif args.command == "run":
+        agent_path = config.AGENTS_DIR / args.agent
+        scenario_path = config.SCENARIOS_DIR / args.scenario
+        agent = Agent.from_file(agent_path)
+        scenario = Scenario.from_file(scenario_path)
+        scheduler = Scheduler(agent=agent, scenarios=[scenario])
+        scheduler.run()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agents.py
+++ b/src/agents.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class Agent:
+    """Simple representation of an Agent loaded from a JSON file."""
+
+    name: str
+    description: str
+
+    @classmethod
+    def from_file(cls, path: Path) -> "Agent":
+        """Load an agent definition from a JSON file."""
+        with path.open("r", encoding="utf-8") as fh:
+            data: dict[str, Any] = json.load(fh)
+        return cls(name=data.get("agent_name", "Unnamed Agent"), description=data.get("description", ""))
+
+    def act(self) -> None:
+        """Trigger the agent's action. For now, simply prints its description."""
+        print(f"[AGENT] {self.name}: {self.description}")

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+# Base directory of the project
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+# Directories containing JSON definitions
+AGENTS_DIR = BASE_DIR / "data" / "agents"
+SCENARIOS_DIR = BASE_DIR / "data" / "scenarios"

--- a/src/scenarios.py
+++ b/src/scenarios.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .agents import Agent
+
+
+@dataclass
+class Scenario:
+    """A scenario that can be executed by an Agent."""
+
+    name: str
+    goal: str
+
+    @classmethod
+    def from_file(cls, path: Path) -> "Scenario":
+        """Load a scenario definition from a JSON file."""
+        with path.open("r", encoding="utf-8") as fh:
+            data: dict[str, Any] = json.load(fh)
+        return cls(name=data.get("scenario_name", "Unnamed Scenario"), goal=data.get("goal", ""))
+
+    def execute(self, agent: Agent) -> None:
+        """Execute the scenario using the provided agent."""
+        print(f"[SCENARIO] {self.name}: {self.goal}")
+        agent.act()

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .agents import Agent
+from .scenarios import Scenario
+
+
+@dataclass
+class Scheduler:
+    """Basic scheduler to run scenarios with a given agent."""
+
+    agent: Agent
+    scenarios: Iterable[Scenario]
+
+    def run(self) -> None:
+        for scenario in self.scenarios:
+            scenario.execute(self.agent)


### PR DESCRIPTION
## Summary
- add modular agent and scenario loaders
- implement basic scheduler and CLI entry point
- include sample JSON data for agents and scenarios

## Testing
- `python main.py list agents`
- `python main.py run Graal_Autopilot_Agent.json Graal_Infinite_Reach.make.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0849535e483338c0f30fbba780f24