### PR TITLE
chore: add Docker setup and CI workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,21 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build image
+        run: docker build -t ghcr.io/${{ github.repository }}/app:${{ github.sha }} .
+
+      - name: Push image
+        run: docker push ghcr.io/${{ github.repository }}/app:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY support_assistant/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY support_assistant/ ./
+
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"
+    depends_on:
+      - redis
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
## Summary
- add Python slim Dockerfile for support assistant app
- introduce docker-compose for app and optional Redis service
- configure GitHub Actions to build and publish Docker image

## Testing
- `python -m py_compile support_assistant/app.py`
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0849226188333958da7a93937dbdb