### PR TITLE
Add cache layer for API calls with configurable invalidation

### DIFF
--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -1,0 +1,75 @@
+"""Simple caching utilities for API responses.
+
+Uses `diskcache` for persistent caching with optional TTL expiration. If
+`diskcache` is not available, falls back to an in-memory LRU cache.
+
+Functions decorated with ``@cached`` gain an ``invalidate`` attribute to clear
+cached values manually.
+"""
+from __future__ import annotations
+
+import os
+from functools import lru_cache, wraps
+from typing import Any, Callable, Optional
+
+try:  # Prefer persistent disk cache when available
+    from diskcache import Cache as DiskCache
+
+    _CACHE_DIR = os.environ.get("CACHE_DIR", ".cache")
+    _disk_cache = DiskCache(_CACHE_DIR)
+
+    def cached(ttl: Optional[int] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Cache decorator with optional TTL using ``diskcache``.
+
+        Args:
+            ttl: Time-to-live in seconds for cached values. ``None`` means no
+                expiration.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            memoized = _disk_cache.memoize(expire=ttl)(func)
+
+            def invalidate(*args: Any, **kwargs: Any) -> None:
+                """Invalidate cached value for specific call or entire cache."""
+                if args or kwargs:
+                    key = _disk_cache.memoize_key(func, *args, **kwargs)
+                    _disk_cache.delete(key)
+                else:
+                    _disk_cache.clear()
+
+            memoized.invalidate = invalidate  # type: ignore[attr-defined]
+            return memoized
+
+        return decorator
+
+    def clear_cache() -> None:
+        """Clear the entire disk cache."""
+        _disk_cache.clear()
+
+except ImportError:  # Fall back to in-memory LRU cache
+    def cached(ttl: Optional[int] = None) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Simple LRU cache decorator.
+
+        ``ttl`` is ignored in this fallback implementation.
+        """
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            cached_func = lru_cache(maxsize=None)(func)
+
+            @wraps(func)
+            def wrapper(*args: Any, **kwargs: Any) -> Any:
+                return cached_func(*args, **kwargs)
+
+            def invalidate() -> None:
+                cached_func.cache_clear()
+
+            wrapper.invalidate = invalidate  # type: ignore[attr-defined]
+            return wrapper
+
+        return decorator
+
+    def clear_cache() -> None:
+        """No-op clear when using LRU cache."""
+        pass
+
+__all__ = ["cached", "clear_cache"]

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,12 +1,21 @@
 from flask import Flask, request, render_template
 import requests
+import os
+import sys
+
+# Ensure project root is on the Python path for imports
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.utils.cache import cached, clear_cache
 
 app = Flask(__name__)
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
 
 
+@cached(ttl=CACHE_TTL_SECONDS)
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
     """Simulate triggering a Make scenario using the provided API token.
     The real implementation should handle errors and actual API calls.
@@ -31,6 +40,14 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/cache/clear", methods=["POST"])
+def clear_cache_route():
+    """Endpoint to manually clear cached API responses."""
+    connect_to_make.invalidate()
+    clear_cache()
+    return "Cache cleared", 200
 
 
 if __name__ == "__main__":

--- a/support_assistant/requirements.txt
+++ b/support_assistant/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 requests
+
+diskcache


### PR DESCRIPTION
## Summary
- add reusable caching utility using diskcache with LRU fallback
- cache Make API calls with configurable TTL and manual clearing endpoint
- include diskcache in requirements

## Testing
- `pip install -r support_assistant/requirements.txt` *(fails: Could not find a version that satisfies the requirement diskcache)*
- `python -m py_compile src/utils/cache.py support_assistant/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0847dbadc833383a13688c3c0ff7c