### PR TITLE
Add Docker setup, Kubernetes infra, and CI/CD pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+PORT=5000
+OWNER_EMAIL=patrickgarnon09@gmail.com
+MAKE_API_BASE=https://api.make.com/v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r support_assistant/requirements.txt
+      - name: Run tests
+        run: pytest
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Docker image
+        run: docker build -t graal-nexus-ai:${{ github.sha }} .
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: azure/setup-kubectl@v3
+        with:
+          version: 'latest'
+      - name: Deploy to Kubernetes
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA }}
+        run: |
+          echo "$KUBE_CONFIG_DATA" | base64 --decode > kubeconfig
+          kubectl --kubeconfig kubeconfig apply -f infra/k8s/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install dependencies
+COPY support_assistant/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY support_assistant/ ./
+
+# Runtime configuration
+ARG PORT=5000
+ENV PORT=${PORT}
+EXPOSE ${PORT}
+
+# Start the application
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ python app.py
 
 Ouvrir ensuite http://localhost:5000 pour saisir le jeton API Make et l'ID du scénario.
 L'adresse du propriétaire est configurée dans `support_assistant/app.py` via `OWNER_EMAIL`.
+
+### 📥 Déploiement Docker
+```bash
+cp .env.example .env  # Modifier les variables si nécessaire
+docker-compose up --build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      args:
+        PORT: ${PORT:-5000}
+    environment:
+      OWNER_EMAIL: ${OWNER_EMAIL:-patrickgarnon09@gmail.com}
+      MAKE_API_BASE: ${MAKE_API_BASE:-https://api.make.com/v2}
+      PORT: ${PORT:-5000}
+    ports:
+      - "${PORT:-5000}:${PORT:-5000}"
+    restart: unless-stopped

--- a/infra/k8s/deployment.yaml
+++ b/infra/k8s/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: graal-nexus-ai
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: graal-nexus-ai
+  template:
+    metadata:
+      labels:
+        app: graal-nexus-ai
+    spec:
+      containers:
+        - name: graal-nexus-ai
+          image: ghcr.io/example/graal-nexus-ai:latest
+          ports:
+            - containerPort: 5000
+          env:
+            - name: OWNER_EMAIL
+              value: "patrickgarnon09@gmail.com"
+            - name: MAKE_API_BASE
+              value: "https://api.make.com/v2"
+            - name: PORT
+              value: "5000"

--- a/infra/k8s/service.yaml
+++ b/infra/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: graal-nexus-ai
+spec:
+  selector:
+    app: graal-nexus-ai
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+  type: LoadBalancer

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,10 +1,12 @@
+import os
 from flask import Flask, request, render_template
 import requests
 
 app = Flask(__name__)
 
-OWNER_EMAIL = "patrickgarnon09@gmail.com"
-MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+# Configuration from environment variables with sensible defaults
+OWNER_EMAIL = os.getenv("OWNER_EMAIL", "patrickgarnon09@gmail.com")
+MAKE_API_BASE = os.getenv("MAKE_API_BASE", "https://api.make.com/v2")  # Placeholder base URL
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
@@ -34,4 +36,6 @@ def install():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    port = int(os.getenv("PORT", "5000"))
+    debug = os.getenv("DEBUG", "True").lower() in ("1", "true", "yes")
+    app.run(host="0.0.0.0", port=port, debug=debug)


### PR DESCRIPTION
## Summary
- dockerize Flask support assistant with env-configurable Dockerfile and docker-compose
- add Kubernetes deployment and service manifests under infra/
- configure GitHub Actions pipeline for test, build, and deploy

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0848056808333a37f303cfd62d885