### PR TITLE
docs: add install guide and development notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY support_assistant/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY support_assistant/ /app
+EXPOSE 5000
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,44 @@ Système IA autonome multi-niches :
 
 ---
 
+## 🛠 Installation
+
+### Via Docker
+
+1. Construire l'image :
+```bash
+docker build -t graal-nexus-ai .
+```
+
+2. Lancer le conteneur :
+```bash
+docker run -p 5000:5000 \
+  -e OWNER_EMAIL=owner@example.com \
+  -e MAKE_API_TOKEN=votre_token_make \
+  -e MAKE_SCENARIO_ID=12345 \
+  graal-nexus-ai
+```
+
+### Variables d'environnement
+
+- `OWNER_EMAIL` : Adresse propriétaire recevant les alertes.
+- `MAKE_API_TOKEN` : Jeton API Make utilisé pour l'authentification.
+- `MAKE_SCENARIO_ID` : Identifiant du scénario Make à déclencher.
+
+---
+
+## 🧩 Architecture
+
+```mermaid
+graph TD
+    A[Utilisateur] -->|HTTP| B[Support Assistant]
+    B -->|API Make| C[Scénario Make]
+    C --> D[Agents]
+    D --> E[Plateformes externes]
+```
+
+---
+
 ## ⚡ Objectif
 Créer un moteur autonome capable de générer, publier et monétiser du contenu en boucle pour atteindre **1M$ de revenus passifs en < 12 mois**.
 
@@ -45,4 +83,4 @@ python app.py
 ```
 
 Ouvrir ensuite http://localhost:5000 pour saisir le jeton API Make et l'ID du scénario.
-L'adresse du propriétaire est configurée dans `support_assistant/app.py` via `OWNER_EMAIL`.
+Ces valeurs ainsi que `OWNER_EMAIL` peuvent aussi être définies via variables d'environnement.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,24 @@
+# Guide de développement
+
+Ce document explique comment étendre les agents IA et les scénarios Make du projet **Graal Nexus AI**.
+
+## 🔧 Étendre les agents
+
+1. Créer un nouveau fichier JSON dans `1-Agents-AI/` décrivant l'agent.
+2. Définir les objectifs, prompts et paramètres spécifiques.
+3. Ajouter l'agent dans votre configuration (voir `examples/`).
+
+## 🛠 Étendre les scénarios
+
+1. Dupliquer un fichier `.make.json` depuis `2-Scenarios-Make/`.
+2. Ajuster les modules et connexions dans Make selon vos besoins.
+3. Mettre à jour les variables d'environnement (`MAKE_SCENARIO_ID`) pour pointer vers le nouveau scénario.
+
+## 🧪 Tests locaux
+
+- Lancer `python -m py_compile support_assistant/app.py` pour vérifier la syntaxe.
+- Exécuter `pytest` pour lancer les tests (aucun test n'est encore fourni).
+
+## 🚀 Contribution
+
+Les contributions sont les bienvenues via pull request. Pensez à documenter toute nouvelle variable d'environnement ou dépendance.

--- a/examples/full_config.yaml
+++ b/examples/full_config.yaml
@@ -1,0 +1,16 @@
+# Exemple de configuration complète pour Graal Nexus AI
+
+env:
+  OWNER_EMAIL: "owner@example.com"
+  MAKE_API_TOKEN: "votre_token_make"
+  MAKE_SCENARIO_ID: "12345"
+
+agents:
+  autopilot: "1-Agents-AI/Graal_Autopilot_Agent.json"
+  sales: "1-Agents-AI/Graal_Sales_Agent.json"
+  oracle: "1-Agents-AI/Graal_Oracle_Mystique.json"
+
+scenarios:
+  autopilot_engine: "2-Scenarios-Make/Graal_Autopilot_Engine.make.json"
+  infinite_reach: "2-Scenarios-Make/Graal_Infinite_Reach.make.json"
+  alert_system: "2-Scenarios-Make/Graal_Alert_System.make.json"

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,9 +1,10 @@
 from flask import Flask, request, render_template
+import os
 import requests
 
 app = Flask(__name__)
 
-OWNER_EMAIL = "patrickgarnon09@gmail.com"
+OWNER_EMAIL = os.getenv("OWNER_EMAIL", "patrickgarnon09@gmail.com")
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
 
 
@@ -25,8 +26,8 @@ def index():
 
 @app.route("/install", methods=["POST"])
 def install():
-    api_token = request.form.get("api_token")
-    scenario_id = request.form.get("scenario_id")
+    api_token = request.form.get("api_token") or os.getenv("MAKE_API_TOKEN")
+    scenario_id = request.form.get("scenario_id") or os.getenv("MAKE_SCENARIO_ID")
     if not api_token or not scenario_id:
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)


### PR DESCRIPTION
## Summary
- document Docker installation, env vars and architecture
- add developer guide for extending agents and scenarios
- include example configuration and Dockerfile

## Testing
- `python -m py_compile support_assistant/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08480e5f08333ac4bd6f061bff145