### PR TITLE
feat: add nexus core modules and entry point

### DIFF
--- a/config/agents.json
+++ b/config/agents.json
@@ -1,0 +1,5 @@
+{
+  "agents": [
+    {"name": "echo", "description": "Simple echo agent"}
+  ]
+}

--- a/config/scenarios.json
+++ b/config/scenarios.json
@@ -1,0 +1,10 @@
+{
+  "scenarios": [
+    {
+      "name": "demo",
+      "steps": [
+        {"agent": "echo", "message": "Hello from scenario"}
+      ]
+    }
+  ]
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,27 @@
+"""Command line entry point for running Nexus scenarios."""
+
+from pathlib import Path
+import sys
+
+# Ensure the src directory is on the path
+ROOT = Path(__file__).parent
+sys.path.append(str(ROOT / "src"))
+
+from nexus.agents import load_agents
+from nexus.scenarios import load_scenarios
+
+
+CONFIG_DIR = ROOT / "config"
+
+
+def main() -> None:
+    agents = load_agents(CONFIG_DIR / "agents.json")
+    scenarios = load_scenarios(CONFIG_DIR / "scenarios.json")
+
+    for scenario in scenarios.values():
+        print(f"Running scenario: {scenario.name}")
+        scenario.run(agents)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -1,0 +1,1 @@
+"""Core Nexus modules for agents, scenarios, and API integrations."""

--- a/src/nexus/agents.py
+++ b/src/nexus/agents.py
@@ -1,0 +1,29 @@
+"""Agent definitions and loader."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+import json
+
+
+@dataclass
+class Agent:
+    """Simple agent representation."""
+
+    name: str
+    config: Dict[str, Any]
+
+    def act(self, message: str) -> str:
+        """Return a response for the given message."""
+        return f"{self.name} received: {message}"
+
+
+def load_agents(path: str) -> Dict[str, Agent]:
+    """Load agent definitions from a JSON config file."""
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    agents = {
+        entry["name"]: Agent(entry["name"], entry)
+        for entry in data.get("agents", [])
+    }
+    return agents

--- a/src/nexus/apis.py
+++ b/src/nexus/apis.py
@@ -1,0 +1,19 @@
+"""Simple API integration placeholder."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class APIIntegration:
+    """Represent an external API integration."""
+
+    name: str
+    base_url: str
+
+    def call(self, endpoint: str, params: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        """Mock an API call.
+
+        In a real implementation, this would perform an HTTP request.
+        """
+        return {"endpoint": endpoint, "params": params or {}, "base_url": self.base_url}

--- a/src/nexus/scenarios.py
+++ b/src/nexus/scenarios.py
@@ -1,0 +1,40 @@
+"""Scenario management and execution."""
+
+from dataclasses import dataclass
+from typing import List, Dict
+import json
+from .agents import Agent
+
+
+@dataclass
+class Step:
+    agent: str
+    message: str
+
+
+@dataclass
+class Scenario:
+    name: str
+    steps: List[Step]
+
+    def run(self, agents: Dict[str, Agent]) -> None:
+        """Execute each step using the provided agents."""
+        for step in self.steps:
+            agent = agents.get(step.agent)
+            if agent is None:
+                raise KeyError(f"Agent '{step.agent}' not found")
+            response = agent.act(step.message)
+            print(response)
+
+
+def load_scenarios(path: str) -> Dict[str, Scenario]:
+    """Load scenarios from a JSON config file."""
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    scenarios: Dict[str, Scenario] = {}
+    for entry in data.get("scenarios", []):
+        steps = [Step(**step) for step in entry.get("steps", [])]
+        scenario = Scenario(name=entry["name"], steps=steps)
+        scenarios[scenario.name] = scenario
+    return scenarios


### PR DESCRIPTION
## Summary
- add simple agent, scenario, and API integration modules under `src/nexus`
- introduce JSON-based configuration and scenario runner `main.py`

## Testing
- `python main.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08485a2588333aac29eb9adefa200