### PR TITLE
feat: containerize support assistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for the support assistant
+# Copy this file to .env and adjust the values
+
+OWNER_EMAIL=patrickgarnon09@gmail.com
+MAKE_API_BASE=https://api.make.com/v2
+MAKE_API_KEY=your_make_api_key
+LOG_LEVEL=INFO

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY support_assistant/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY support_assistant/ ./
+EXPOSE 5000
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -46,3 +46,35 @@ python app.py
 
 Ouvrir ensuite http://localhost:5000 pour saisir le jeton API Make et l'ID du scénario.
 L'adresse du propriétaire est configurée dans `support_assistant/app.py` via `OWNER_EMAIL`.
+
+### ⚙️ Configuration
+Copier le fichier d'exemple et renseigner vos valeurs sensibles :
+
+```bash
+cp .env.example .env
+# Éditer .env pour définir MAKE_API_KEY, LOG_LEVEL, etc.
+```
+
+### 🐳 Docker
+Construire l'image et exécuter le conteneur :
+
+```bash
+docker build -t graal-support-assistant .
+docker run --env-file .env -p 5000:5000 graal-support-assistant
+```
+
+Avec Docker Compose :
+
+```bash
+docker-compose up --build
+```
+
+### ☁️ Déploiement Cloud
+- **AWS ECS** :
+  1. `docker build -t <account>.dkr.ecr.<region>.amazonaws.com/graal-support-assistant:latest .`
+  2. Pousser l'image sur ECR puis créer un service ECS Fargate exposant le port 5000.
+  3. Configurer l'Auto Scaling (nombre minimal/maximal de tâches) selon la charge.
+- **GCP Cloud Run** :
+  1. `gcloud builds submit --tag gcr.io/<project>/graal-support-assistant`
+  2. `gcloud run deploy graal-support-assistant --image gcr.io/<project>/graal-support-assistant --platform managed --allow-unauthenticated`
+  3. Ajuster le nombre maximal d'instances via `--max-instances` pour le scaling automatique.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  support_assistant:
+    build: .
+    env_file:
+      - .env
+    ports:
+      - "5000:5000"

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,17 +1,28 @@
+import os
+import logging
 from flask import Flask, request, render_template
+from dotenv import load_dotenv
 import requests
+
+load_dotenv()
 
 app = Flask(__name__)
 
-OWNER_EMAIL = "patrickgarnon09@gmail.com"
-MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+OWNER_EMAIL = os.getenv("OWNER_EMAIL", "patrickgarnon09@gmail.com")
+MAKE_API_BASE = os.getenv("MAKE_API_BASE", "https://api.make.com/v2")
+MAKE_API_KEY = os.getenv("MAKE_API_KEY")
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO))
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
     """Simulate triggering a Make scenario using the provided API token.
+    Falls back to the MAKE_API_KEY environment variable if no token is supplied.
     The real implementation should handle errors and actual API calls.
     """
-    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
+    token = api_token or MAKE_API_KEY
+    headers = {"Authorization": f"Token {token}", "Content-Type": "application/json"}
     # Example request (commented out as this environment has no external access)
     # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
     # return response.json()
@@ -25,13 +36,13 @@ def index():
 
 @app.route("/install", methods=["POST"])
 def install():
-    api_token = request.form.get("api_token")
+    api_token = request.form.get("api_token") or MAKE_API_KEY
     scenario_id = request.form.get("scenario_id")
     if not api_token or not scenario_id:
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
-    return f"Scenario {result['scenario']} triggered with status {result['status']}."
+    return f"Scenario {result['scenario']} triggered with status {result['status']}"
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0", debug=True)

--- a/support_assistant/requirements.txt
+++ b/support_assistant/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment settings with python-dotenv
- add Dockerfile and docker-compose for the support assistant
- document container build, run and cloud deployment

## Testing
- `python -m py_compile support_assistant/app.py`
- `pip install -r support_assistant/requirements.txt` *(fails: Could not connect to proxy)*
- `docker build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0848a21f08333b6b7f79c7659c3b9