### PR TITLE
Add caching and parallel scenario execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ python app.py
 
 Ouvrir ensuite http://localhost:5000 pour saisir le jeton API Make et l'ID du scénario.
 L'adresse du propriétaire est configurée dans `support_assistant/app.py` via `OWNER_EMAIL`.
+
+### 🧠 Cache et parallélisation
+
+- Les appels à l'API Make sont mis en cache via `functools.lru_cache` (32 entrées). Cela évite de répéter des requêtes identiques.
+- Le cache est propre au processus et peut être vidé manuellement via l'endpoint `POST /cache/clear` ou automatiquement lorsque la capacité est atteinte.
+- Pour publier sur plusieurs scénarios en parallèle, indiquez plusieurs IDs séparés par des virgules. Le traitement s'effectue via `ThreadPoolExecutor` pour accélérer les publications multicanales.

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,5 +1,7 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import requests
+from functools import lru_cache
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 app = Flask(__name__)
 
@@ -7,15 +9,35 @@ OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
 
 
+@lru_cache(maxsize=32)
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
     """Simulate triggering a Make scenario using the provided API token.
     The real implementation should handle errors and actual API calls.
+
+    Results are cached to avoid repeating identical calls.
     """
     headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
     # Example request (commented out as this environment has no external access)
     # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
     # return response.json()
     return {"status": "connected", "scenario": scenario_id}
+
+
+def publish_to_channels(api_token: str, scenario_ids: list[str]) -> dict:
+    """Trigger multiple scenarios in parallel."""
+    results = {}
+    with ThreadPoolExecutor() as executor:
+        futures = {
+            executor.submit(connect_to_make, api_token, sid.strip()): sid.strip()
+            for sid in scenario_ids
+        }
+        for future in as_completed(futures):
+            sid = futures[future]
+            try:
+                results[sid] = future.result()
+            except Exception as exc:  # pragma: no cover - demonstration only
+                results[sid] = {"status": "error", "detail": str(exc)}
+    return results
 
 
 @app.route("/", methods=["GET"])
@@ -29,8 +51,20 @@ def install():
     scenario_id = request.form.get("scenario_id")
     if not api_token or not scenario_id:
         return "Missing credentials", 400
-    result = connect_to_make(api_token, scenario_id)
+    # Allow comma-separated IDs for multichannel publication
+    if "," in scenario_id:
+        ids = scenario_id.split(",")
+        results = publish_to_channels(api_token, ids)
+        return jsonify(results)
+    result = connect_to_make(api_token, scenario_id.strip())
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/cache/clear", methods=["POST"])
+def clear_cache():
+    """Endpoint to invalidate cached Make responses."""
+    connect_to_make.cache_clear()
+    return "Cache cleared", 200
 
 
 if __name__ == "__main__":

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -9,9 +9,9 @@
     <form action="/install" method="post">
         <label for="api_token">API Token Make:</label>
         <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
+        <label for="scenario_id">ID Scénario (séparés par des virgules pour multicanal):</label>
         <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
+        <button type="submit">Installer / Publier</button>
     </form>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- cache Make API calls with `lru_cache` and add cache clearing endpoint
- run scenarios in parallel via `ThreadPoolExecutor` when multiple IDs are provided
- document cache behaviour and multichannel support

## Testing
- `python -m py_compile support_assistant/app.py`
- `python - <<'PY'
from support_assistant.app import connect_to_make, publish_to_channels, clear_cache
print(connect_to_make('t','1'))
print(connect_to_make('t','1'))
print(publish_to_channels('t',['1','2']))
clear_cache()
print('cache size', connect_to_make.cache_info())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a08488cd848333bef3ee50c5ab5a89