### PR TITLE
feat: add structured logging module

### DIFF
--- a/nexus/__init__.py
+++ b/nexus/__init__.py
@@ -1,0 +1,1 @@
+# Nexus package initialization

--- a/nexus/logging.py
+++ b/nexus/logging.py
@@ -1,0 +1,50 @@
+"""Central logging utilities for the Nexus project.
+
+Provides a JSON-formatted logger with configurable levels via
+environment variable or command-line option.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import json
+from typing import Optional
+
+
+class JsonFormatter(logging.Formatter):
+    """Format log records as JSON for cloud-friendly logging."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            "time": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            log_record["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+def setup_logging(level: Optional[str] = None) -> logging.Logger:
+    """Configure root logger.
+
+    The log level can be provided directly, through the ``level`` argument,
+    via the ``LOG_LEVEL`` environment variable, or defaults to ``INFO``.
+    """
+
+    level_name = level or os.getenv("LOG_LEVEL", "INFO")
+    level_name = level_name.upper()
+    logging.basicConfig(level=getattr(logging, level_name, logging.INFO))
+    formatter = JsonFormatter()
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        handler.setFormatter(formatter)
+    return root_logger
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a logger with the given name."""
+    return logging.getLogger(name)
+

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,7 +1,12 @@
 from flask import Flask, request, render_template
 import requests
+import argparse
+import os
+
+from nexus.logging import get_logger, setup_logging
 
 app = Flask(__name__)
+logger = get_logger(__name__)
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
@@ -11,27 +16,45 @@ def connect_to_make(api_token: str, scenario_id: str) -> dict:
     """Simulate triggering a Make scenario using the provided API token.
     The real implementation should handle errors and actual API calls.
     """
+
+    logger.debug("Connecting to Make scenario %s", scenario_id)
     headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
     # Example request (commented out as this environment has no external access)
     # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
+    # logger.debug("Make API response: %s", response.text)
     # return response.json()
+    logger.info("Simulated Make scenario %s triggered", scenario_id)
     return {"status": "connected", "scenario": scenario_id}
 
 
 @app.route("/", methods=["GET"])
 def index():
+    logger.info("Rendering index page")
     return render_template("index.html")
 
 
 @app.route("/install", methods=["POST"])
 def install():
+    logger.info("Install endpoint called")
     api_token = request.form.get("api_token")
     scenario_id = request.form.get("scenario_id")
     if not api_token or not scenario_id:
+        logger.error("Missing credentials: api_token=%s scenario_id=%s", bool(api_token), bool(scenario_id))
         return "Missing credentials", 400
+    logger.debug("Triggering Make scenario %s", scenario_id)
     result = connect_to_make(api_token, scenario_id)
+    logger.info("Scenario %s triggered with status %s", result['scenario'], result['status'])
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Support assistant service")
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        help="Logging level (e.g. INFO, DEBUG, ERROR). Overrides LOG_LEVEL env var.",
+    )
+    args = parser.parse_args()
+    setup_logging(args.log_level)
+    logger.debug("Starting Flask app with log level %s", args.log_level or os.getenv("LOG_LEVEL", "INFO"))
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- add centralized logging utilities with JSON formatting and env/CLI log level
- instrument Flask orchestrator with debug/info/error logs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m support_assistant.app --help`


------
https://chatgpt.com/codex/tasks/task_e_68a08486626883338855aef954c3d1b4