### PR TITLE
Add Make and Runway endpoints with Tailwind front

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import requests
 
 app = Flask(__name__)
@@ -18,19 +18,40 @@ def connect_to_make(api_token: str, scenario_id: str) -> dict:
     return {"status": "connected", "scenario": scenario_id}
 
 
+def generate_runway_video(prompt: str) -> dict:
+    """Simulate a Runway video generation call.
+    This placeholder simply returns the prompt back with a dummy status.
+    """
+    # Example request (commented out as this environment has no external access)
+    # response = requests.post("https://api.runwayml.com/v1/generate", json={"prompt": prompt})
+    # return response.json()
+    return {"status": "generated", "prompt": prompt}
+
+
 @app.route("/", methods=["GET"])
 def index():
     return render_template("index.html")
 
 
-@app.route("/install", methods=["POST"])
-def install():
-    api_token = request.form.get("api_token")
-    scenario_id = request.form.get("scenario_id")
+@app.route("/make/run", methods=["POST"])
+def make_run():
+    data = request.get_json(silent=True) or {}
+    api_token = data.get("api_token") or request.form.get("api_token")
+    scenario_id = data.get("scenario_id") or request.form.get("scenario_id")
     if not api_token or not scenario_id:
-        return "Missing credentials", 400
+        return jsonify({"error": "Missing credentials"}), 400
     result = connect_to_make(api_token, scenario_id)
-    return f"Scenario {result['scenario']} triggered with status {result['status']}."
+    return jsonify(result)
+
+
+@app.route("/runway/generate", methods=["POST"])
+def runway_generate():
+    data = request.get_json(silent=True) or {}
+    prompt = data.get("prompt") or request.form.get("prompt")
+    if not prompt:
+        return jsonify({"error": "Missing prompt"}), 400
+    result = generate_runway_video(prompt)
+    return jsonify(result)
 
 
 if __name__ == "__main__":

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -3,15 +3,64 @@
 <head>
     <meta charset="UTF-8">
     <title>Assistant Support AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Assistant Support AI</h1>
-    <form action="/install" method="post">
-        <label for="api_token">API Token Make:</label>
-        <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
-        <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
-    </form>
+<body class="bg-gray-100 p-8">
+    <h1 class="text-2xl font-bold mb-6">Assistant Support AI</h1>
+
+    <div class="space-y-8">
+        <form id="makeRunForm" class="bg-white p-4 rounded shadow space-y-4">
+            <h2 class="text-xl font-semibold">Exécuter un scénario Make</h2>
+            <input type="text" id="make_api_token" name="api_token" placeholder="API Token Make" class="border p-2 w-full" required>
+            <input type="text" id="make_scenario_id" name="scenario_id" placeholder="ID Scénario" class="border p-2 w-full" required>
+            <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Lancer</button>
+            <div id="makeRunResult" class="text-sm mt-2"></div>
+        </form>
+
+        <form id="runwayForm" class="bg-white p-4 rounded shadow space-y-4">
+            <h2 class="text-xl font-semibold">Génération Runway</h2>
+            <input type="text" id="runway_prompt" name="prompt" placeholder="Prompt vidéo" class="border p-2 w-full" required>
+            <button type="submit" class="bg-green-600 text-white px-4 py-2 rounded">Générer</button>
+            <div id="runwayResult" class="text-sm mt-2"></div>
+        </form>
+    </div>
+
+    <script>
+    async function postJSON(url, data) {
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(data)
+        });
+        const text = await response.text();
+        try { return {ok: response.ok, json: JSON.parse(text)}; }
+        catch { return {ok: response.ok, json: text}; }
+    }
+
+    document.getElementById('makeRunForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const api_token = document.getElementById('make_api_token').value;
+        const scenario_id = document.getElementById('make_scenario_id').value;
+        const resultEl = document.getElementById('makeRunResult');
+        try {
+            const res = await postJSON('/make/run', {api_token, scenario_id});
+            resultEl.textContent = res.ok ? JSON.stringify(res.json) : 'Erreur: ' + JSON.stringify(res.json);
+        } catch (err) {
+            resultEl.textContent = 'Erreur: ' + err;
+        }
+    });
+
+    document.getElementById('runwayForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const prompt = document.getElementById('runway_prompt').value;
+        const resultEl = document.getElementById('runwayResult');
+        try {
+            const res = await postJSON('/runway/generate', {prompt});
+            resultEl.textContent = res.ok ? JSON.stringify(res.json) : 'Erreur: ' + JSON.stringify(res.json);
+        } catch (err) {
+            resultEl.textContent = 'Erreur: ' + err;
+        }
+    });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add POST /make/run to trigger Make scenarios
- add POST /runway/generate to simulate Runway video generation
- add Tailwind forms to call new endpoints and show responses

## Testing
- `python -m py_compile support_assistant/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a083d88c848333af95dac54e10f358