### PR TITLE
Add ElevenLabs voice endpoint and audio player

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,5 +1,6 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, Response
 import requests
+from integrations.elevenlabs import get_voice_audio
 
 app = Flask(__name__)
 
@@ -31,6 +32,16 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/elevenlabs/voice/<voice_id>", methods=["GET"])
+def elevenlabs_voice(voice_id: str):
+    api_key = request.args.get("api_key")
+    text = request.args.get("text", "Bonjour")
+    if not api_key:
+        return "Missing API key", 400
+    audio = get_voice_audio(api_key, voice_id, text)
+    return Response(audio, mimetype="audio/mpeg")
 
 
 if __name__ == "__main__":

--- a/support_assistant/integrations/elevenlabs.py
+++ b/support_assistant/integrations/elevenlabs.py
@@ -1,0 +1,27 @@
+import requests
+
+ELEVENLABS_API_BASE = "https://api.elevenlabs.io/v1"
+
+def get_voice_audio(api_key: str, voice_id: str, text: str) -> bytes:
+    """Generate speech audio using ElevenLabs API.
+
+    Args:
+        api_key: ElevenLabs API key.
+        voice_id: Identifier of the voice to use.
+        text: Text to synthesize.
+
+    Returns:
+        Audio content in MPEG format as bytes.
+    """
+    headers = {
+        "xi-api-key": api_key,
+        "Accept": "audio/mpeg",
+    }
+    data = {"text": text}
+    response = requests.post(
+        f"{ELEVENLABS_API_BASE}/text-to-speech/{voice_id}",
+        headers=headers,
+        json=data,
+    )
+    response.raise_for_status()
+    return response.content

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -3,15 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <title>Assistant Support AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Assistant Support AI</h1>
-    <form action="/install" method="post">
-        <label for="api_token">API Token Make:</label>
-        <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
-        <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
+<body class="bg-gray-900 text-white p-4">
+    <h1 class="text-2xl mb-4">Assistant Support AI</h1>
+    <form action="/install" method="post" class="space-y-2">
+        <label for="api_token" class="block">API Token Make:</label>
+        <input type="text" id="api_token" name="api_token" required class="text-black p-1"><br>
+        <label for="scenario_id" class="block">ID Scénario:</label>
+        <input type="text" id="scenario_id" name="scenario_id" required class="text-black p-1"><br>
+        <button type="submit" class="bg-blue-600 px-4 py-2">Installer</button>
     </form>
+    <audio id="voice-player" controls class="mt-6 w-full"></audio>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate ElevenLabs text-to-speech API
- expose `/elevenlabs/voice/<id>` endpoint streaming audio
- add Tailwind-styled audio player in UI

## Testing
- `pytest`
- `python -m py_compile app.py integrations/elevenlabs.py`


------
https://chatgpt.com/codex/tasks/task_e_68a083d7320083339226a5d0bd7a8403