### PR TITLE
Add Runway history endpoint and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,11 @@ python app.py
 
 Ouvrir ensuite http://localhost:5000 pour saisir le jeton API Make et l'ID du scénario.
 L'adresse du propriétaire est configurée dans `support_assistant/app.py` via `OWNER_EMAIL`.
+
+### 🎞️ Intégration Runway
+L'application inclut un module `integrations/runway.py` pour récupérer les vidéos générées par Runway et les stocker dans une base SQLite locale (`videos.db`).
+
+- `GET /runway/history` renvoie l'historique des vidéos en JSON.
+- `GET /runway/history/ui` affiche une page listant les vidéos avec un lecteur intégré.
+
+Définir la variable d'environnement `RUNWAY_API_KEY` pour synchroniser automatiquement les jobs Runway lors de l'accès à l'historique.

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,7 +1,11 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
+import os
 import requests
 
+from integrations.runway import init_db, get_history, sync_jobs
+
 app = Flask(__name__)
+init_db()
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
@@ -31,6 +35,24 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/runway/history", methods=["GET"])
+def runway_history():
+    api_key = os.environ.get("RUNWAY_API_KEY")
+    if api_key:
+        try:
+            sync_jobs(api_key)
+        except requests.RequestException:
+            pass
+    videos = get_history()
+    return jsonify(videos)
+
+
+@app.route("/runway/history/ui", methods=["GET"])
+def runway_history_ui():
+    videos = get_history()
+    return render_template("runway_history.html", videos=videos)
 
 
 if __name__ == "__main__":

--- a/support_assistant/integrations/runway.py
+++ b/support_assistant/integrations/runway.py
@@ -1,0 +1,74 @@
+import os
+import sqlite3
+from typing import List, Dict
+
+import requests
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+DB_PATH = os.path.join(BASE_DIR, "videos.db")
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create the videos table if it does not already exist."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS videos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            job_id TEXT,
+            video_url TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def fetch_jobs(api_key: str) -> List[Dict]:
+    """Retrieve jobs from the Runway API."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    response = requests.get(
+        "https://api.runwayml.com/v1/jobs", headers=headers, timeout=10
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data.get("results", [])
+
+
+def store_jobs(jobs: List[Dict], db_path: str = DB_PATH) -> None:
+    """Store job data containing videos into the database."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    for job in jobs:
+        video_url = job.get("output", {}).get("video")
+        if not video_url:
+            continue
+        cursor.execute(
+            "INSERT INTO videos (job_id, video_url, created_at) VALUES (?, ?, ?)",
+            (job.get("id"), video_url, job.get("created_at")),
+        )
+    conn.commit()
+    conn.close()
+
+
+def sync_jobs(api_key: str, db_path: str = DB_PATH) -> None:
+    """Fetch jobs from Runway and store them in the local database."""
+    jobs = fetch_jobs(api_key)
+    store_jobs(jobs, db_path)
+
+
+def get_history(db_path: str = DB_PATH) -> List[Dict]:
+    """Return the stored video generations."""
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT job_id, video_url, created_at FROM videos ORDER BY id DESC"
+    )
+    rows = cursor.fetchall()
+    conn.close()
+    return [
+        {"job_id": job_id, "video_url": video_url, "created_at": created_at}
+        for job_id, video_url, created_at in rows
+    ]

--- a/support_assistant/templates/runway_history.html
+++ b/support_assistant/templates/runway_history.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Historique Runway</title>
+</head>
+<body>
+    <h1>Historique des vidéos Runway</h1>
+    {% if videos %}
+        <ul>
+        {% for video in videos %}
+            <li>
+                <p>Job: {{ video.job_id }} – {{ video.created_at }}</p>
+                <video controls width="320">
+                    <source src="{{ video.video_url }}" type="video/mp4">
+                    Votre navigateur ne supporte pas la vidéo.
+                </video>
+            </li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>Aucune vidéo disponible.</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate Runway API client storing video jobs in a local SQLite database
- expose `/runway/history` JSON endpoint and `/runway/history/ui` page with embedded video player
- document Runway integration and new endpoints

## Testing
- `python -m py_compile support_assistant/app.py support_assistant/integrations/runway.py && echo 'py_compile success'`


------
https://chatgpt.com/codex/tasks/task_e_68a083d574e48333a2cb2588c017763e