### PR TITLE
Add Make API stats endpoint and dashboard

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,5 +1,6 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import requests
+from integrations.make import get_scenario_stats
 
 app = Flask(__name__)
 
@@ -31,6 +32,21 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/make/stats", methods=["GET"])
+def make_stats():
+    api_token = request.args.get("api_token")
+    scenario_id = request.args.get("scenario_id")
+    if not api_token or not scenario_id:
+        return jsonify({"error": "Missing credentials"}), 400
+    stats = get_scenario_stats(api_token, scenario_id)
+    return jsonify(stats)
+
+
+@app.route("/make/dashboard", methods=["GET"])
+def make_dashboard():
+    return render_template("make_stats.html")
 
 
 if __name__ == "__main__":

--- a/support_assistant/integrations/make.py
+++ b/support_assistant/integrations/make.py
@@ -1,0 +1,42 @@
+"""Integration helpers for the Make API."""
+import requests
+from typing import Dict
+
+MAKE_API_BASE = "https://api.make.com/v2"
+
+
+def get_scenario_stats(api_token: str, scenario_id: str) -> Dict[str, float]:
+    """Return key metrics for a Make scenario.
+
+    Parameters
+    ----------
+    api_token: str
+        Personal access token for the Make API.
+    scenario_id: str
+        Identifier of the scenario to inspect.
+
+    Returns
+    -------
+    dict
+        Dictionary containing metrics such as total operations, success rate
+        and average execution time. On error, an ``error`` key is added with
+        a message and the metrics default to ``0``.
+    """
+    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
+    url = f"{MAKE_API_BASE}/scenarios/{scenario_id}/statistics"
+    try:
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return {
+            "total_operations": data.get("operationsCount", 0),
+            "success_rate": data.get("successRate", 0),
+            "avg_exec_time": data.get("executionTimeAvg", 0),
+        }
+    except Exception as exc:  # pragma: no cover - network failures not tested
+        return {
+            "error": str(exc),
+            "total_operations": 0,
+            "success_rate": 0,
+            "avg_exec_time": 0,
+        }

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -13,5 +13,8 @@
         <input type="text" id="scenario_id" name="scenario_id" required><br>
         <button type="submit">Installer</button>
     </form>
+    <p>
+        <a href="/make/dashboard">Voir les statistiques du scénario</a>
+    </p>
 </body>
 </html>

--- a/support_assistant/templates/make_stats.html
+++ b/support_assistant/templates/make_stats.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Statistiques Make</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-gray-100 p-6">
+    <div class="max-w-4xl mx-auto">
+        <h1 class="text-2xl font-bold mb-4">Statistiques du scénario</h1>
+        <div class="mb-4">
+            <input id="api_token" type="text" placeholder="API Token" class="border p-2 mr-2">
+            <input id="scenario_id" type="text" placeholder="ID Scénario" class="border p-2 mr-2">
+            <button id="load" class="bg-blue-500 text-white px-4 py-2">Charger</button>
+        </div>
+        <div id="cards" class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+            <div class="bg-white p-4 shadow rounded" id="card-operations">
+                <h2 class="text-lg font-semibold">Opérations totales</h2>
+                <p class="text-3xl" id="total_operations">0</p>
+            </div>
+            <div class="bg-white p-4 shadow rounded" id="card-success">
+                <h2 class="text-lg font-semibold">Taux de réussite</h2>
+                <p class="text-3xl" id="success_rate">0%</p>
+            </div>
+            <div class="bg-white p-4 shadow rounded" id="card-time">
+                <h2 class="text-lg font-semibold">Temps moyen</h2>
+                <p class="text-3xl" id="avg_exec_time">0 ms</p>
+            </div>
+        </div>
+        <canvas id="statsChart" class="bg-white p-4 shadow rounded"></canvas>
+    </div>
+    <script>
+        document.getElementById('load').addEventListener('click', async () => {
+            const token = document.getElementById('api_token').value;
+            const scenario = document.getElementById('scenario_id').value;
+            const response = await fetch(`/make/stats?api_token=${token}&scenario_id=${scenario}`);
+            const data = await response.json();
+            document.getElementById('total_operations').textContent = data.total_operations;
+            document.getElementById('success_rate').textContent = data.success_rate + '%';
+            document.getElementById('avg_exec_time').textContent = data.avg_exec_time + ' ms';
+            const ctx = document.getElementById('statsChart');
+            new Chart(ctx, {
+                type: 'bar',
+                data: {
+                    labels: ['Opérations', 'Taux de réussite', 'Temps moyen'],
+                    datasets: [{
+                        label: 'Statistiques',
+                        data: [data.total_operations, data.success_rate, data.avg_exec_time],
+                        backgroundColor: ['#3b82f6', '#10b981', '#f59e0b']
+                    }]
+                },
+                options: {scales: {y: {beginAtZero: true}}}
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Make API integration helper for scenario statistics
- Provide `/make/stats` JSON endpoint and dashboard template
- Include Tailwind/Chart.js UI to display operations, success rate, and average time

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a083d48d648333b8bc47a3109833dd