### PR TITLE
Add Shopify orders stream via WebSocket

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,10 +1,38 @@
 from flask import Flask, request, render_template
 import requests
+from flask_socketio import SocketIO
+
+from integrations.shopify import client_from_env
 
 app = Flask(__name__)
+socketio = SocketIO(app, cors_allowed_origins="*")
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+
+# Shopify client (optional if env vars not provided)
+try:
+    shopify_client = client_from_env()
+except Exception:
+    shopify_client = None
+
+
+def poll_orders() -> None:
+    """Background task polling Shopify for new orders and emitting them."""
+    if not shopify_client:
+        return
+    last_id = None
+    while True:
+        try:
+            orders = shopify_client.get_orders(since_id=last_id)
+            for order in orders:
+                socketio.emit("order", order, namespace="/shopify-stream")
+                order_id = order.get("id")
+                if order_id:
+                    last_id = max(last_id or 0, order_id)
+        except Exception:
+            pass
+        socketio.sleep(10)
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
@@ -23,6 +51,12 @@ def index():
     return render_template("index.html")
 
 
+@socketio.on("connect", namespace="/shopify-stream")
+def shopify_stream_connect():
+    # Connection event placeholder
+    pass
+
+
 @app.route("/install", methods=["POST"])
 def install():
     api_token = request.form.get("api_token")
@@ -34,4 +68,6 @@ def install():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    if shopify_client:
+        socketio.start_background_task(poll_orders)
+    socketio.run(app, debug=True)

--- a/support_assistant/integrations/shopify.py
+++ b/support_assistant/integrations/shopify.py
@@ -1,0 +1,39 @@
+import os
+from typing import Dict, List, Optional
+
+import requests
+
+
+class ShopifyClient:
+    """Minimal client for querying the Shopify Orders API."""
+
+    def __init__(self, store: str, access_token: str, api_version: str = "2023-07") -> None:
+        self.store = store
+        self.access_token = access_token
+        self.api_version = api_version
+        self.base_url = f"https://{store}/admin/api/{api_version}"
+
+    def get_orders(self, since_id: Optional[int] = None) -> List[Dict]:
+        """Return a list of orders newer than ``since_id``."""
+        params = {"status": "any", "limit": 50}
+        if since_id:
+            params["since_id"] = since_id
+        headers = {"X-Shopify-Access-Token": self.access_token}
+        response = requests.get(f"{self.base_url}/orders.json", headers=headers, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json().get("orders", [])
+
+
+def client_from_env() -> ShopifyClient:
+    """Create a :class:`ShopifyClient` using environment variables.
+
+    Required variables::
+
+        SHOPIFY_STORE -- e.g. ``myshop.myshopify.com``
+        SHOPIFY_ACCESS_TOKEN -- private app access token
+    """
+    store = os.getenv("SHOPIFY_STORE")
+    token = os.getenv("SHOPIFY_ACCESS_TOKEN")
+    if not store or not token:
+        raise ValueError("Missing Shopify credentials")
+    return ShopifyClient(store, token)

--- a/support_assistant/requirements.txt
+++ b/support_assistant/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 requests
+flask-socketio

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -3,15 +3,40 @@
 <head>
     <meta charset="UTF-8">
     <title>Assistant Support AI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="/socket.io/socket.io.js"></script>
 </head>
 <body>
-    <h1>Assistant Support AI</h1>
-    <form action="/install" method="post">
-        <label for="api_token">API Token Make:</label>
-        <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
-        <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
-    </form>
+    <div class="max-w-xl mx-auto p-4">
+        <h1 class="text-2xl font-bold mb-4">Assistant Support AI</h1>
+        <form action="/install" method="post" class="space-y-2">
+            <div>
+                <label for="api_token" class="block">API Token Make:</label>
+                <input class="border p-1 w-full" type="text" id="api_token" name="api_token" required>
+            </div>
+            <div>
+                <label for="scenario_id" class="block">ID Scénario:</label>
+                <input class="border p-1 w-full" type="text" id="scenario_id" name="scenario_id" required>
+            </div>
+            <button class="bg-blue-500 text-white px-4 py-2 rounded" type="submit">Installer</button>
+        </form>
+
+        <div class="mt-8">
+            <h2 class="text-xl font-semibold mb-2">Ventes Shopify</h2>
+            <ul id="sales-list" class="space-y-1"></ul>
+        </div>
+    </div>
+
+    <script>
+        const socket = io('/shopify-stream');
+        const list = document.getElementById('sales-list');
+        socket.on('order', function(order){
+            const item = document.createElement('li');
+            item.className = 'border p-2 rounded';
+            const name = order.customer ? `${order.customer.first_name} ${order.customer.last_name}` : 'Client';
+            item.textContent = `#${order.id} - ${name} - ${order.total_price} ${order.currency}`;
+            list.prepend(item);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate minimal Shopify Orders client
- stream Shopify sales to clients via WebSocket
- show live sales in Tailwind UI

## Testing
- `python -m py_compile support_assistant/app.py support_assistant/integrations/shopify.py`
- `python -m pytest`
- `pip install -r support_assistant/requirements.txt` *(fails: Could not find a version that satisfies the requirement flask-socketio)*

------
https://chatgpt.com/codex/tasks/task_e_68a083d2f6e88333bac1c134d77baca9