### PR TITLE
Add FastAPI scaffold with environment loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app/.env

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,4 @@
+SHOPIFY_API_KEY=your_shopify_api_key
+MAKE_API_KEY=your_make_api_key
+RUNWAY_API_KEY=your_runway_api_key
+ELEVENLABS_API_KEY=your_elevenlabs_api_key

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from fastapi import FastAPI, Request
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from dotenv import load_dotenv
+import os
+
+BASE_DIR = Path(__file__).resolve().parent
+load_dotenv(BASE_DIR / '.env')
+
+SHOPIFY_API_KEY = os.getenv('SHOPIFY_API_KEY')
+MAKE_API_KEY = os.getenv('MAKE_API_KEY')
+RUNWAY_API_KEY = os.getenv('RUNWAY_API_KEY')
+ELEVENLABS_API_KEY = os.getenv('ELEVENLABS_API_KEY')
+
+app = FastAPI()
+
+templates = Jinja2Templates(directory=str(BASE_DIR / 'templates'))
+app.mount('/static', StaticFiles(directory=str(BASE_DIR / 'static')), name='static')
+
+@app.get('/', response_class=HTMLResponse)
+async def read_root(request: Request):
+    return templates.TemplateResponse('index.html', {'request': request})
+

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,1 @@
+/* Tailwind CSS output will be placed here */

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Graal Nexus AI</title>
+    <link href="/static/styles.css" rel="stylesheet">
+</head>
+<body class="font-sans">
+    <h1 class="text-2xl font-bold">Hello from Graal Nexus AI</h1>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- scaffold FastAPI app with root HTML template
- load Shopify, Make, Runway, and ElevenLabs keys from environment
- add static and template directories for future Tailwind assets

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a083d23a1c83338b94125693706119