### PR TITLE
feat: add tailwind base and ui templates

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -23,6 +23,16 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/shopify", methods=["GET"])
+def shopify():
+    return render_template("shopify.html")
+
+
+@app.route("/make", methods=["GET"])
+def make_view():
+    return render_template("make.html")
+
+
 @app.route("/install", methods=["POST"])
 def install():
     api_token = request.form.get("api_token")

--- a/support_assistant/templates/base.html
+++ b/support_assistant/templates/base.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <title>{% block title %}Graal Nexus AI{% endblock %}</title>
+</head>
+<body class="bg-gray-900 text-gray-100">
+    {% block content %}{% endblock %}
+</body>
+</html>

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -1,17 +1,18 @@
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <title>Assistant Support AI</title>
-</head>
-<body>
-    <h1>Assistant Support AI</h1>
-    <form action="/install" method="post">
-        <label for="api_token">API Token Make:</label>
-        <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
-        <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
+{% extends "base.html" %}
+{% block title %}Assistant Support AI{% endblock %}
+{% block content %}
+<div class="max-w-md mx-auto p-4 md:max-w-lg">
+    <h1 class="text-2xl font-bold mb-4">Assistant Support AI</h1>
+    <form action="/install" method="post" class="flex flex-col gap-4">
+        <div class="flex flex-col">
+            <label for="api_token" class="mb-1">API Token Make:</label>
+            <input type="text" id="api_token" name="api_token" class="p-2 rounded bg-gray-800 text-gray-100" required>
+        </div>
+        <div class="flex flex-col">
+            <label for="scenario_id" class="mb-1">ID Scénario:</label>
+            <input type="text" id="scenario_id" name="scenario_id" class="p-2 rounded bg-gray-800 text-gray-100" required>
+        </div>
+        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded">Installer</button>
     </form>
-</body>
-</html>
+</div>
+{% endblock %}

--- a/support_assistant/templates/make.html
+++ b/support_assistant/templates/make.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block title %}Make Scenario{% endblock %}
+{% block content %}
+<div class="p-4 flex flex-col gap-4 md:flex-row">
+    <div class="flex-1 bg-gray-800 p-4 rounded shadow">
+        <h2 class="text-xl font-bold mb-2">Scenario Info</h2>
+        <p>Manage your Make scenarios.</p>
+        <button class="mt-4 bg-green-600 hover:bg-green-700 text-white py-2 px-4 rounded">Run</button>
+    </div>
+    <div class="flex-1 bg-gray-800 p-4 rounded shadow">
+        <h2 class="text-xl font-bold mb-2">Logs</h2>
+        <table class="min-w-full text-left">
+            <thead>
+                <tr>
+                    <th class="px-2 py-1">Time</th>
+                    <th class="px-2 py-1">Event</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="border-t border-gray-700">
+                    <td class="px-2 py-1">10:00</td>
+                    <td class="px-2 py-1">Start</td>
+                </tr>
+                <tr class="border-t border-gray-700">
+                    <td class="px-2 py-1">10:05</td>
+                    <td class="px-2 py-1">Finished</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/support_assistant/templates/shopify.html
+++ b/support_assistant/templates/shopify.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Shopify Dashboard{% endblock %}
+{% block content %}
+<div class="p-4">
+    <div class="grid gap-4 md:grid-cols-2">
+        <div class="bg-gray-800 p-4 rounded shadow">
+            <h2 class="text-xl font-bold mb-2">Sales</h2>
+            <p>Details about sales.</p>
+            <button class="mt-4 bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded">View More</button>
+        </div>
+        <div class="bg-gray-800 p-4 rounded shadow">
+            <h2 class="text-xl font-bold mb-2">Orders</h2>
+            <table class="min-w-full text-left">
+                <thead>
+                    <tr>
+                        <th class="px-2 py-1">Order</th>
+                        <th class="px-2 py-1">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr class="border-t border-gray-700">
+                        <td class="px-2 py-1">#1001</td>
+                        <td class="px-2 py-1">Shipped</td>
+                    </tr>
+                    <tr class="border-t border-gray-700">
+                        <td class="px-2 py-1">#1002</td>
+                        <td class="px-2 py-1">Pending</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Tailwind CSS base template with dark theme
- create responsive Shopify and Make pages
- wire new templates into Flask routes

## Testing
- `python -m py_compile app.py`
- `pytest`
- `python support_assistant/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a083ceec388333a56fae7a19ee0bbc