### PR TITLE
feat: add Make dashboard with trigger and stats

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,5 +1,7 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, redirect, url_for
 import requests
+
+from dashboard.services.make import fetch_campaign_stats, trigger_scenario
 
 app = Flask(__name__)
 
@@ -8,14 +10,8 @@ MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
-    """Simulate triggering a Make scenario using the provided API token.
-    The real implementation should handle errors and actual API calls.
-    """
-    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
-    # Example request (commented out as this environment has no external access)
-    # response = requests.post(f"{MAKE_API_BASE}/scenarios/{scenario_id}/run", headers=headers)
-    # return response.json()
-    return {"status": "connected", "scenario": scenario_id}
+    """Trigger a Make scenario using the provided API token."""
+    return trigger_scenario(api_token, scenario_id)
 
 
 @app.route("/", methods=["GET"])
@@ -31,6 +27,40 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/make", methods=["GET"])
+def make_dashboard():
+    api_token = request.args.get("api_token")
+    scenario_id = request.args.get("scenario_id")
+    status = request.args.get("status")
+    stats = None
+    if api_token and scenario_id:
+        stats = fetch_campaign_stats(api_token, scenario_id)
+    return render_template(
+        "make.html",
+        stats=stats,
+        api_token=api_token,
+        scenario_id=scenario_id,
+        status=status,
+    )
+
+
+@app.route("/make/trigger/<scenario_id>", methods=["POST"])
+def trigger_make(scenario_id):
+    api_token = request.form.get("api_token")
+    if not api_token:
+        return "Missing API token", 400
+    result = trigger_scenario(api_token, scenario_id)
+    status = "success" if result.get("status") == "success" else "error"
+    return redirect(
+        url_for(
+            "make_dashboard",
+            api_token=api_token,
+            scenario_id=scenario_id,
+            status=status,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/support_assistant/dashboard/__init__.py
+++ b/support_assistant/dashboard/__init__.py
@@ -1,0 +1,1 @@
+# Dashboard package

--- a/support_assistant/dashboard/services/__init__.py
+++ b/support_assistant/dashboard/services/__init__.py
@@ -1,0 +1,1 @@
+# Services for dashboard

--- a/support_assistant/dashboard/services/make.py
+++ b/support_assistant/dashboard/services/make.py
@@ -1,0 +1,36 @@
+"""Make API service utilities."""
+
+import requests
+
+MAKE_API_BASE = "https://api.make.com/v2"
+
+def trigger_scenario(api_token: str, scenario_id: str) -> dict:
+    """Trigger a Make scenario and return the execution status."""
+    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
+    url = f"{MAKE_API_BASE}/scenarios/{scenario_id}/executions"
+    try:
+        response = requests.post(url, headers=headers)
+        response.raise_for_status()
+        return {"status": "success"}
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        return {"status": "error", "message": str(exc)}
+
+def fetch_campaign_stats(api_token: str, scenario_id: str) -> dict:
+    """Fetch execution statistics for a Make scenario."""
+    headers = {"Authorization": f"Token {api_token}", "Content-Type": "application/json"}
+    url = f"{MAKE_API_BASE}/scenarios/{scenario_id}/executions"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        executions = response.json().get("data", [])
+        execution_count = len(executions)
+        success_count = sum(1 for e in executions if e.get("status") == "success")
+        success_rate = (success_count / execution_count * 100) if execution_count else 0
+        messages = [e.get("message", "") for e in executions[-5:]]
+        return {
+            "execution_count": execution_count,
+            "success_rate": success_rate,
+            "messages": messages,
+        }
+    except requests.RequestException as exc:  # pragma: no cover - network errors
+        return {"error": str(exc)}

--- a/support_assistant/templates/make.html
+++ b/support_assistant/templates/make.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard Make</title>
+</head>
+<body>
+    <h1>Dashboard Make</h1>
+    <form method="get" action="/make">
+        <label for="api_token">API Token Make:</label>
+        <input type="text" id="api_token" name="api_token" value="{{ api_token or '' }}" required>
+        <label for="scenario_id">ID Scénario:</label>
+        <input type="text" id="scenario_id" name="scenario_id" value="{{ scenario_id or '' }}" required>
+        <button type="submit">Charger</button>
+    </form>
+
+    {% if status %}
+    <p>Statut déclenchement: {{ status }}</p>
+    {% endif %}
+
+    {% if stats %}
+    <h2>Statistiques</h2>
+    <p>Nombre d'exécutions: {{ stats.execution_count }}</p>
+    <p>Taux de réussite: {{ stats.success_rate }}%</p>
+    <h3>Derniers messages</h3>
+    <ul>
+    {% for msg in stats.messages %}
+        <li>{{ msg }}</li>
+    {% endfor %}
+    </ul>
+    <form method="post" action="/make/trigger/{{ scenario_id }}">
+        <input type="hidden" name="api_token" value="{{ api_token }}">
+        <button type="submit">Déclencher</button>
+    </form>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add service utilities to query Make scenario executions and trigger runs
- expose `/make` dashboard with scenario stats and `/make/trigger/<id>` action
- show trigger status in UI

## Testing
- `python -m py_compile app.py dashboard/services/make.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a083cc7e8c8333b1dab9f1500c5cdc