### PR TITLE
Add Flask dashboard with Tailwind dark mode

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,32 @@
+from flask import Flask, render_template
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html', title='Home')
+
+
+@app.route('/shopify')
+def shopify():
+    return render_template('shopify.html', title='Shopify')
+
+
+@app.route('/make')
+def make():
+    return render_template('make.html', title='Make')
+
+
+@app.route('/runway')
+def runway():
+    return render_template('runway.html', title='Runway')
+
+
+@app.route('/elevenlabs')
+def elevenlabs():
+    return render_template('elevenlabs.html', title='ElevenLabs')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Jinja2
+uvicorn

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full" x-data="{ dark: true }" x-bind:class="{ 'dark': dark }">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %}Dashboard{% endblock %}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+        }
+    </script>
+</head>
+<body class="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+    <div class="container mx-auto p-4">
+        <button onclick="document.documentElement.classList.toggle('dark')" class="mb-4 px-4 py-2 bg-gray-200 dark:bg-gray-800 rounded">Toggle Theme</button>
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/dashboard/templates/elevenlabs.html
+++ b/dashboard/templates/elevenlabs.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}ElevenLabs{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold">ElevenLabs</h1>
+{% endblock %}

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Home{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold">Home</h1>
+{% endblock %}

--- a/dashboard/templates/make.html
+++ b/dashboard/templates/make.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Make{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold">Make</h1>
+{% endblock %}

--- a/dashboard/templates/runway.html
+++ b/dashboard/templates/runway.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Runway{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold">Runway</h1>
+{% endblock %}

--- a/dashboard/templates/shopify.html
+++ b/dashboard/templates/shopify.html
@@ -1,0 +1,5 @@
+{% extends 'base.html' %}
+{% block title %}Shopify{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold">Shopify</h1>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add Flask dashboard app with routes for Shopify, Make, Runway, and ElevenLabs
- include Tailwind-powered Jinja templates with dark mode toggle
- document dependencies in dashboard requirements file

## Testing
- `python -m py_compile dashboard/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a083c90058833388c307df5da69373