### PR TITLE
Add Make.com scenario builder utilities

### DIFF
--- a/docs/make_scenario_builder.md
+++ b/docs/make_scenario_builder.md
@@ -1,0 +1,60 @@
+# Make Scenario Builder
+
+Utilities for constructing and running [Make.com](https://www.make.com/) scenarios.
+
+## Installation
+
+```bash
+pip install -r requirements.txt  # if a requirements file exists
+```
+
+The modules live under `scripts/make_scenario_builder` and can be imported in
+Python via:
+
+```python
+from scripts.make_scenario_builder import (
+    MakeAPI,
+    create_scenario,
+    clone_scenario,
+    update_scenario,
+    run_scenario,
+    chain_http_modules,
+    OpenRouterClient,
+    RunwayClient,
+    ElevenLabsClient,
+    run_autopilot,
+)
+```
+
+## Usage
+
+### Managing Scenarios
+
+```python
+api = MakeAPI("<api-key>")
+scenario = create_scenario(api, "demo", modules=[{"type": "http", "url": "https://example.com"}])
+clone = clone_scenario(api, scenario["id"])
+update_scenario(api, clone["id"], {"name": "updated"})
+run_scenario(api, clone["id"])
+```
+
+### Chaining HTTP Modules
+
+```python
+chain_http_modules(api, clone["id"], ["https://a.com", "https://b.com"])
+```
+
+### Provider Clients
+
+```python
+orc = OpenRouterClient("<key>")
+orc.invoke("Hello, world!")
+```
+
+### Autopilot
+
+```python
+result = run_autopilot(api, clone["id"], [{"name": "tuned"}])
+```
+
+This will run the scenario and apply adjustments if the execution fails.

--- a/scripts/make_scenario_builder/__init__.py
+++ b/scripts/make_scenario_builder/__init__.py
@@ -1,0 +1,25 @@
+"""Utility tools for building and running Make.com scenarios."""
+
+from .api import MakeAPI
+from .builder import (
+    create_scenario,
+    clone_scenario,
+    update_scenario,
+    run_scenario,
+    chain_http_modules,
+)
+from .providers import OpenRouterClient, RunwayClient, ElevenLabsClient
+from .autopilot import run_autopilot
+
+__all__ = [
+    "MakeAPI",
+    "create_scenario",
+    "clone_scenario",
+    "update_scenario",
+    "run_scenario",
+    "chain_http_modules",
+    "OpenRouterClient",
+    "RunwayClient",
+    "ElevenLabsClient",
+    "run_autopilot",
+]

--- a/scripts/make_scenario_builder/_requests.py
+++ b/scripts/make_scenario_builder/_requests.py
@@ -1,0 +1,50 @@
+"""Very small subset of the :mod:`requests` API used for testing.
+
+This module provides ``get``, ``post`` and ``put`` functions returning objects
+with ``json`` and ``raise_for_status`` methods. It relies solely on the Python
+standard library and is intentionally lightweight – network calls are rarely
+executed in tests where the functions are typically mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from urllib import request, error
+
+
+class Response:
+    def __init__(self, data: str, status: int):
+        self._data = data
+        self.status_code = status
+
+    def json(self) -> dict:
+        return json.loads(self._data) if self._data else {}
+
+    def raise_for_status(self) -> None:
+        if not (200 <= self.status_code < 300):
+            raise error.HTTPError(None, self.status_code, "HTTP error", hdrs=None, fp=None)
+
+
+def _send(method: str, url: str, headers: dict | None = None, payload: dict | None = None) -> Response:
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = request.Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with request.urlopen(req) as resp:
+            body = resp.read().decode()
+            status = resp.getcode()
+    except error.HTTPError as e:
+        body = e.read().decode()
+        status = e.code
+    return Response(body, status)
+
+
+def post(url: str, headers: dict | None = None, json: dict | None = None) -> Response:  # noqa: A002
+    return _send("POST", url, headers, json)
+
+
+def get(url: str, headers: dict | None = None) -> Response:
+    return _send("GET", url, headers)
+
+
+def put(url: str, headers: dict | None = None, json: dict | None = None) -> Response:  # noqa: A002
+    return _send("PUT", url, headers, json)

--- a/scripts/make_scenario_builder/api.py
+++ b/scripts/make_scenario_builder/api.py
@@ -1,0 +1,70 @@
+"""Wrapper for the Make.com API."""
+
+from __future__ import annotations
+
+from . import _requests as requests
+
+
+class MakeAPI:
+    """Minimal wrapper around the Make.com REST API.
+
+    Parameters
+    ----------
+    api_key: str
+        API key used for authenticating with Make.com.
+    base_url: str, optional
+        Base URL of the Make.com API. Defaults to ``https://api.make.com/v2``.
+    """
+
+    def __init__(self, api_key: str, base_url: str = "https://api.make.com/v2"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    # ------------------------------------------------------------------
+    @property
+    def headers(self) -> dict:
+        """Return default headers for API requests."""
+
+        return {"Authorization": f"Bearer {self.api_key}"}
+
+    # ------------------------------------------------------------------
+    def create_scenario(self, data: dict) -> dict:
+        """Create a scenario."""
+
+        response = requests.post(
+            f"{self.base_url}/scenarios", headers=self.headers, json=data
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    def read_scenario(self, scenario_id: int | str) -> dict:
+        """Retrieve information about a scenario."""
+
+        response = requests.get(
+            f"{self.base_url}/scenarios/{scenario_id}", headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    def update_scenario(self, scenario_id: int | str, data: dict) -> dict:
+        """Update a scenario."""
+
+        response = requests.put(
+            f"{self.base_url}/scenarios/{scenario_id}",
+            headers=self.headers,
+            json=data,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    def run_scenario(self, scenario_id: int | str) -> dict:
+        """Execute a scenario on Make.com."""
+
+        response = requests.post(
+            f"{self.base_url}/scenarios/{scenario_id}/run", headers=self.headers
+        )
+        response.raise_for_status()
+        return response.json()

--- a/scripts/make_scenario_builder/autopilot.py
+++ b/scripts/make_scenario_builder/autopilot.py
@@ -1,0 +1,46 @@
+"""Automatically tune and run Make.com scenarios."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .builder import run_scenario, update_scenario
+
+
+def run_autopilot(
+    api,
+    scenario_id: int | str,
+    adjustments: Iterable[dict],
+    max_attempts: int = 3,
+) -> dict:
+    """Run a scenario and apply adjustments on failure.
+
+    Parameters
+    ----------
+    api:
+        Instance of :class:`~scripts.make_scenario_builder.api.MakeAPI`.
+    scenario_id:
+        ID of the scenario to run.
+    adjustments:
+        Iterable of dictionaries to apply via :func:`update_scenario` when the
+        scenario does not report success.
+    max_attempts:
+        Maximum number of times to run the scenario.
+    """
+
+    result: dict | None = None
+    attempts = 0
+    adj_iter = iter(adjustments)
+
+    while attempts < max_attempts:
+        attempts += 1
+        result = run_scenario(api, scenario_id)
+        if result.get("status") == "success":
+            break
+        try:
+            update = next(adj_iter)
+        except StopIteration:
+            continue
+        update_scenario(api, scenario_id, update)
+
+    return result or {}

--- a/scripts/make_scenario_builder/builder.py
+++ b/scripts/make_scenario_builder/builder.py
@@ -1,0 +1,42 @@
+"""Utilities for composing Make.com scenarios."""
+
+from __future__ import annotations
+
+from .api import MakeAPI
+
+
+def create_scenario(api: MakeAPI, name: str, modules: list | None = None) -> dict:
+    """Create a new scenario with an optional list of modules."""
+
+    payload = {"name": name}
+    if modules:
+        payload["modules"] = modules
+    return api.create_scenario(payload)
+
+
+def clone_scenario(api: MakeAPI, scenario_id: int | str) -> dict:
+    """Clone an existing scenario."""
+
+    original = api.read_scenario(scenario_id)
+    original.pop("id", None)
+    original["name"] = f"{original.get('name', 'scenario')} (clone)"
+    return api.create_scenario(original)
+
+
+def update_scenario(api: MakeAPI, scenario_id: int | str, updates: dict) -> dict:
+    """Update a scenario with the provided data."""
+
+    return api.update_scenario(scenario_id, updates)
+
+
+def run_scenario(api: MakeAPI, scenario_id: int | str) -> dict:
+    """Run a scenario."""
+
+    return api.run_scenario(scenario_id)
+
+
+def chain_http_modules(api: MakeAPI, scenario_id: int | str, urls: list[str]) -> dict:
+    """Replace the scenario's modules with a chain of HTTP modules calling ``urls``."""
+
+    modules = [{"type": "http", "url": url} for url in urls]
+    return update_scenario(api, scenario_id, {"modules": modules})

--- a/scripts/make_scenario_builder/providers.py
+++ b/scripts/make_scenario_builder/providers.py
@@ -1,0 +1,55 @@
+"""HTTP clients for common AI service providers."""
+
+from __future__ import annotations
+
+from . import _requests as requests
+
+
+class OpenRouterClient:
+    """Client for the OpenRouter API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://openrouter.ai/api/v1"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    def invoke(self, prompt: str, model: str = "gpt-3.5-turbo", **kwargs) -> dict:
+        url = f"{self.base_url}/chat/completions"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        payload.update(kwargs)
+        response = requests.post(url, headers=headers, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+class RunwayClient:
+    """Client for the RunwayML API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://api.runwayml.com/v1"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    def invoke(self, model: str, inputs: dict) -> dict:
+        url = f"{self.base_url}/models/{model}/invoke"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(url, headers=headers, json={"input": inputs})
+        response.raise_for_status()
+        return response.json()
+
+
+class ElevenLabsClient:
+    """Client for the ElevenLabs API."""
+
+    def __init__(self, api_key: str, base_url: str = "https://api.elevenlabs.io/v1"):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+
+    def invoke(self, text: str, voice: str = "default") -> dict:
+        url = f"{self.base_url}/text-to-speech/{voice}"
+        headers = {"xi-api-key": self.api_key}
+        response = requests.post(url, headers=headers, json={"text": text})
+        response.raise_for_status()
+        return response.json()

--- a/tests/test_make_scenario_builder.py
+++ b/tests/test_make_scenario_builder.py
@@ -1,0 +1,137 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import MagicMock, patch
+
+from scripts.make_scenario_builder.api import MakeAPI
+from scripts.make_scenario_builder import builder
+from scripts.make_scenario_builder.providers import (
+    OpenRouterClient,
+    RunwayClient,
+    ElevenLabsClient,
+)
+from scripts.make_scenario_builder.autopilot import run_autopilot
+
+
+# ---------------------------------------------------------------------------
+# API wrapper tests
+# ---------------------------------------------------------------------------
+
+def test_makeapi_crud_and_run():
+    api = MakeAPI("token")
+    with patch("scripts.make_scenario_builder.api.requests.post") as post, \
+         patch("scripts.make_scenario_builder.api.requests.get") as get, \
+         patch("scripts.make_scenario_builder.api.requests.put") as put:
+
+        post.return_value.json.return_value = {"id": 1}
+        post.return_value.raise_for_status.return_value = None
+        assert api.create_scenario({"name": "demo"}) == {"id": 1}
+        post.assert_called_with(
+            "https://api.make.com/v2/scenarios",
+            headers={"Authorization": "Bearer token"},
+            json={"name": "demo"},
+        )
+
+        post.reset_mock()
+        post.return_value.json.return_value = {"status": "success"}
+        api.run_scenario(1)
+        post.assert_called_with(
+            "https://api.make.com/v2/scenarios/1/run",
+            headers={"Authorization": "Bearer token"},
+        )
+
+        get.return_value.json.return_value = {"id": 1}
+        get.return_value.raise_for_status.return_value = None
+        api.read_scenario(1)
+        get.assert_called_with(
+            "https://api.make.com/v2/scenarios/1",
+            headers={"Authorization": "Bearer token"},
+        )
+
+        put.return_value.json.return_value = {"ok": True}
+        put.return_value.raise_for_status.return_value = None
+        api.update_scenario(1, {"name": "x"})
+        put.assert_called_with(
+            "https://api.make.com/v2/scenarios/1",
+            headers={"Authorization": "Bearer token"},
+            json={"name": "x"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Builder tests
+# ---------------------------------------------------------------------------
+
+def test_builder_functions():
+    api = MagicMock(spec=MakeAPI)
+    api.read_scenario.return_value = {"id": 1, "name": "orig"}
+
+    builder.create_scenario(api, "new", [1])
+    api.create_scenario.assert_called_with({"name": "new", "modules": [1]})
+
+    builder.clone_scenario(api, 1)
+    api.read_scenario.assert_called_with(1)
+    api.create_scenario.assert_called_with({"name": "orig (clone)"})
+
+    builder.update_scenario(api, 1, {"x": 2})
+    api.update_scenario.assert_called_with(1, {"x": 2})
+
+    builder.run_scenario(api, 1)
+    api.run_scenario.assert_called_with(1)
+
+    builder.chain_http_modules(api, 1, ["u1", "u2"])
+    api.update_scenario.assert_called_with(
+        1,
+        {
+            "modules": [
+                {"type": "http", "url": "u1"},
+                {"type": "http", "url": "u2"},
+            ]
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Provider tests
+# ---------------------------------------------------------------------------
+
+def test_provider_clients():
+    with patch("scripts.make_scenario_builder.providers.requests.post") as post:
+        post.return_value.json.return_value = {"result": 1}
+        post.return_value.raise_for_status.return_value = None
+
+        orc = OpenRouterClient("k")
+        assert orc.invoke("hi") == {"result": 1}
+        url, kwargs = post.call_args
+        assert url[0] == "https://openrouter.ai/api/v1/chat/completions"
+        assert kwargs["headers"] == {"Authorization": "Bearer k"}
+
+        rc = RunwayClient("k")
+        rc.invoke("model", {"a": 1})
+        url, kwargs = post.call_args
+        assert url[0] == "https://api.runwayml.com/v1/models/model/invoke"
+        assert kwargs["json"] == {"input": {"a": 1}}
+
+        el = ElevenLabsClient("k")
+        el.invoke("text")
+        url, kwargs = post.call_args
+        assert url[0] == "https://api.elevenlabs.io/v1/text-to-speech/default"
+        assert kwargs["headers"] == {"xi-api-key": "k"}
+
+
+# ---------------------------------------------------------------------------
+# Autopilot tests
+# ---------------------------------------------------------------------------
+
+def test_run_autopilot_updates_on_failure():
+    api = object()
+    with patch("scripts.make_scenario_builder.autopilot.run_scenario") as run, \
+         patch("scripts.make_scenario_builder.autopilot.update_scenario") as upd:
+        run.side_effect = [
+            {"status": "error"},
+            {"status": "success"},
+        ]
+        result = run_autopilot(api, 1, [{"modules": []}])
+        assert result["status"] == "success"
+        upd.assert_called_once_with(api, 1, {"modules": []})
+        assert run.call_count == 2


### PR DESCRIPTION
## Summary
- implement Make.com API wrapper with scenario management and execution helpers
- add scenario builder functions and provider clients for OpenRouter, Runway, and ElevenLabs
- introduce autopilot tuning logic with documentation and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a081f5d8b883338771b67a2505a330