### PR TITLE
Add Runway video generation service and UI

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,7 +1,12 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import requests
+from typing import List
+
+from runway_service import RunwayVideo, create_video
 
 app = Flask(__name__)
+
+videos: List[RunwayVideo] = []
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
@@ -21,6 +26,38 @@ def connect_to_make(api_token: str, scenario_id: str) -> dict:
 @app.route("/", methods=["GET"])
 def index():
     return render_template("index.html")
+
+
+def _video_to_dict(video: RunwayVideo) -> dict:
+    return {
+        "id": video.id,
+        "title": video.title,
+        "url": video.url,
+        "date": video.date.isoformat(),
+        "status": video.status,
+    }
+
+
+@app.route("/runway/videos", methods=["GET"])
+def list_runway_videos():
+    page = int(request.args.get("page", 1))
+    per_page = int(request.args.get("per_page", 10))
+    start = (page - 1) * per_page
+    end = start + per_page
+    data = [_video_to_dict(v) for v in videos[start:end]]
+    return jsonify({"videos": data, "page": page, "total": len(videos)})
+
+
+@app.route("/runway/generate", methods=["POST"])
+def generate_runway_video():
+    payload = request.get_json() or {}
+    prompt = payload.get("prompt")
+    params = payload.get("params", {})
+    if not prompt:
+        return jsonify({"error": "prompt is required"}), 400
+    video = create_video(prompt, params, api_key="")
+    videos.append(video)
+    return jsonify(_video_to_dict(video)), 201
 
 
 @app.route("/install", methods=["POST"])

--- a/support_assistant/runway_service.py
+++ b/support_assistant/runway_service.py
@@ -1,0 +1,61 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict
+
+import requests
+
+RUNWAY_API_BASE = "https://api.runwayml.com/v1"  # Placeholder base URL
+
+
+@dataclass
+class RunwayVideo:
+    id: str
+    title: str
+    url: str
+    date: datetime
+    status: str
+
+
+def create_video(prompt: str, params: Dict[str, str], api_key: str) -> RunwayVideo:
+    """Create a video via the Runway API."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {"prompt": prompt, **params}
+    # response = requests.post(f"{RUNWAY_API_BASE}/videos", json=payload, headers=headers)
+    # data = response.json()
+    # Mocked response for offline environment
+    data = {
+        "id": f"vid_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}",
+        "title": prompt,
+        "url": "",
+        "status": "processing",
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    return RunwayVideo(
+        id=data["id"],
+        title=data["title"],
+        url=data["url"],
+        date=datetime.fromisoformat(data["created_at"]),
+        status=data["status"],
+    )
+
+
+def get_video_status(video_id: str, api_key: str) -> RunwayVideo:
+    """Retrieve the status of a Runway video."""
+    headers = {"Authorization": f"Bearer {api_key}"}
+    # response = requests.get(f"{RUNWAY_API_BASE}/videos/{video_id}", headers=headers)
+    # data = response.json()
+    # Mocked response for offline environment
+    data = {
+        "id": video_id,
+        "title": "Sample",
+        "url": "https://example.com/video.mp4",
+        "status": "completed",
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    return RunwayVideo(
+        id=data["id"],
+        title=data["title"],
+        url=data["url"],
+        date=datetime.fromisoformat(data["created_at"]),
+        status=data["status"],
+    )

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -2,16 +2,79 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
-    <title>Assistant Support AI</title>
+    <title>Runway Videos</title>
+    <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-    <h1>Assistant Support AI</h1>
-    <form action="/install" method="post">
-        <label for="api_token">API Token Make:</label>
-        <input type="text" id="api_token" name="api_token" required><br>
-        <label for="scenario_id">ID Scénario:</label>
-        <input type="text" id="scenario_id" name="scenario_id" required><br>
-        <button type="submit">Installer</button>
-    </form>
+<body class="p-4">
+    <h1 class="text-2xl mb-4">Runway Videos</h1>
+    <button id="openForm" class="bg-blue-500 text-white px-4 py-2 rounded">Générer</button>
+
+    <div id="formContainer" class="hidden mt-4">
+        <form id="generateForm" class="space-y-2">
+            <input class="border p-2 w-full" type="text" name="prompt" placeholder="Prompt" required>
+            <input class="border p-2 w-full" type="text" name="params" placeholder='Paramètres JSON ({"key":"value"})'>
+            <button class="bg-green-500 text-white px-4 py-2 rounded" type="submit">Lancer</button>
+        </form>
+    </div>
+
+    <table class="table-auto w-full mt-4 border">
+        <thead>
+            <tr class="bg-gray-200">
+                <th class="border px-2">ID</th>
+                <th class="border px-2">Titre</th>
+                <th class="border px-2">URL</th>
+                <th class="border px-2">Date</th>
+                <th class="border px-2">Statut</th>
+            </tr>
+        </thead>
+        <tbody id="videosBody"></tbody>
+    </table>
+
+    <script>
+        async function loadVideos() {
+            const res = await fetch('/runway/videos');
+            const data = await res.json();
+            const body = document.getElementById('videosBody');
+            body.innerHTML = '';
+            data.videos.forEach(v => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td class="border px-2">${v.id}</td>
+                    <td class="border px-2">${v.title}</td>
+                    <td class="border px-2"><a class="text-blue-500" href="${v.url}">${v.url}</a></td>
+                    <td class="border px-2">${v.date}</td>
+                    <td class="border px-2">${v.status}</td>
+                `;
+                body.appendChild(tr);
+            });
+        }
+
+        document.getElementById('openForm').addEventListener('click', () => {
+            document.getElementById('formContainer').classList.toggle('hidden');
+        });
+
+        document.getElementById('generateForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const form = e.target;
+            const prompt = form.prompt.value;
+            let params = {};
+            try {
+                params = form.params.value ? JSON.parse(form.params.value) : {};
+            } catch (err) {
+                alert('Paramètres JSON invalides');
+                return;
+            }
+            await fetch('/runway/generate', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({prompt, params})
+            });
+            form.reset();
+            document.getElementById('formContainer').classList.add('hidden');
+            loadVideos();
+        });
+
+        loadVideos();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Runway service with `RunwayVideo` model and mocked API calls
- expose `/runway/videos` and `/runway/generate` endpoints
- provide Tailwind interface to list videos and trigger new generations

## Testing
- `python -m py_compile support_assistant/app.py support_assistant/runway_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68a083c3c35c8333a95bce92202aaa69