### PR TITLE
Add Make API stats endpoint, caching and charts

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,10 +1,17 @@
-from flask import Flask, request, render_template
+from flask import Flask, request, render_template, jsonify
 import requests
+from datetime import datetime, timedelta
+
+from make_service import MakeService
 
 app = Flask(__name__)
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+
+# Cache simple en mémoire pour les statistiques
+CACHE = {}
+CACHE_TTL = timedelta(minutes=5)
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
@@ -18,9 +25,29 @@ def connect_to_make(api_token: str, scenario_id: str) -> dict:
     return {"status": "connected", "scenario": scenario_id}
 
 
+def _get_cached_stats(token: str) -> dict:
+    """Retourne les stats depuis le cache ou l'API."""
+    cache_key = f"stats:{token}"
+    entry = CACHE.get(cache_key)
+    if entry:
+        data, ts = entry
+        if datetime.utcnow() - ts < CACHE_TTL:
+            return data
+    service = MakeService(token)
+    data = service.get_stats()
+    CACHE[cache_key] = (data, datetime.utcnow())
+    return data
+
+
 @app.route("/", methods=["GET"])
 def index():
     return render_template("index.html")
+
+
+@app.route("/stats", methods=["GET"])
+def stats_page():
+    """Page HTML dédiée aux graphiques."""
+    return render_template("stats.html")
 
 
 @app.route("/install", methods=["POST"])
@@ -31,6 +58,15 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/make/stats", methods=["GET"])
+def make_stats():
+    token = request.args.get("api_token") or request.headers.get("X-API-Token")
+    if not token:
+        return jsonify({"error": "Missing API token"}), 400
+    data = _get_cached_stats(token)
+    return jsonify(data)
 
 
 if __name__ == "__main__":

--- a/support_assistant/make_service.py
+++ b/support_assistant/make_service.py
@@ -1,0 +1,35 @@
+import time
+from typing import Dict
+import requests
+
+
+class MakeService:
+    """Client simple pour l'API Make utilisant un token ou OAuth."""
+
+    def __init__(self, api_token: str, base_url: str = "https://api.make.com/v2") -> None:
+        self.api_token = api_token
+        self.base_url = base_url.rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Token {self.api_token}",
+            "Content-Type": "application/json",
+        }
+
+    def get_stats(self) -> Dict[str, float]:
+        """Récupère les statistiques principales depuis l'API Make.
+
+        Renvoie un dictionnaire avec les clés:
+          - daily_executions: int
+          - errors: int
+          - average_time: float
+        """
+        url = f"{self.base_url}/stats"
+        response = requests.get(url, headers=self._headers(), timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return {
+            "daily_executions": data.get("daily_executions", 0),
+            "errors": data.get("errors", 0),
+            "average_time": data.get("average_time", 0.0),
+        }

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -13,5 +13,6 @@
         <input type="text" id="scenario_id" name="scenario_id" required><br>
         <button type="submit">Installer</button>
     </form>
+    <p><a href="/stats">Voir les statistiques</a></p>
 </body>
 </html>

--- a/support_assistant/templates/stats.html
+++ b/support_assistant/templates/stats.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Statistiques Make</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="p-4">
+    <h1 class="text-2xl font-bold mb-4">Statistiques Make</h1>
+    <div class="mb-4">
+        <input id="token" type="text" placeholder="API Token" class="border p-2 mr-2" />
+        <button onclick="loadStats()" class="bg-blue-500 text-white px-4 py-2">Charger</button>
+    </div>
+    <canvas id="statsChart" class="w-full max-w-lg"></canvas>
+
+    <script>
+    async function loadStats() {
+        const token = document.getElementById('token').value;
+        const res = await fetch(`/make/stats?api_token=${encodeURIComponent(token)}`);
+        const data = await res.json();
+        const ctx = document.getElementById('statsChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: ['Exécutions', 'Erreurs', 'Temps moyen'],
+                datasets: [{
+                    label: 'Stats journalières',
+                    data: [data.daily_executions, data.errors, data.average_time],
+                    backgroundColor: ['#60a5fa', '#f87171', '#34d399']
+                }]
+            }
+        });
+    }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement MakeService to call Make API and retrieve stats
- expose `/make/stats` endpoint with in-memory caching
- add simple Tailwind/Chart.js UI to display stats

## Testing
- `python -m compileall -f support_assistant`


------
https://chatgpt.com/codex/tasks/task_e_68a083c227e48333ba6d3c343f5bd4fa