### PR TITLE
Add FastAPI dashboard with Tailwind templates and simple auth

### DIFF
--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from fastapi import FastAPI, Depends, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from starlette.middleware.sessions import SessionMiddleware
+import os
+
+
+TOKEN = os.getenv("DASHBOARD_TOKEN", "changeme")
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI dashboard application."""
+    app = FastAPI()
+    templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+    app.add_middleware(SessionMiddleware, secret_key=os.getenv("SESSION_SECRET", "secret"))
+
+    def get_current_user(request: Request) -> str:
+        user = request.session.get("user")
+        if not user:
+            raise HTTPException(status_code=401)
+        return user
+
+    @app.get("/login", response_class=HTMLResponse)
+    async def login_form(request: Request) -> HTMLResponse:
+        return templates.TemplateResponse("login.html", {"request": request})
+
+    @app.post("/login")
+    async def login(request: Request, token: str = Form(...)) -> RedirectResponse:
+        if token != TOKEN:
+            return templates.TemplateResponse(
+                "login.html", {"request": request, "error": "Invalid token"}, status_code=400
+            )
+        request.session["user"] = "admin"
+        return RedirectResponse(url="/", status_code=303)
+
+    @app.get("/logout")
+    async def logout(request: Request) -> RedirectResponse:
+        request.session.clear()
+        return RedirectResponse(url="/login", status_code=303)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index(request: Request, user: str = Depends(get_current_user)) -> HTMLResponse:
+        return templates.TemplateResponse("index.html", {"request": request, "user": user})
+
+    return app

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+jinja2
+python-multipart

--- a/dashboard/templates/base.html
+++ b/dashboard/templates/base.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: 'class' }
+    </script>
+    <title>{% block title %}Dashboard{% endblock %}</title>
+</head>
+<body class="bg-gray-900 text-gray-100">
+    <nav class="bg-gray-800 p-4">
+        <ul class="flex space-x-4">
+            <li><a href="/shopify" class="hover:underline">Shopify Sales</a></li>
+            <li><a href="/make" class="hover:underline">Make Campaigns</a></li>
+            <li><a href="/runway" class="hover:underline">Runway Videos</a></li>
+            <li><a href="/elevenlabs" class="hover:underline">ElevenLabs Player</a></li>
+        </ul>
+    </nav>
+    <main class="p-4">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h1 class="text-2xl mb-4">Welcome, {{ user }}!</h1>
+<p>Select a section from the navigation above.</p>
+{% endblock %}

--- a/dashboard/templates/login.html
+++ b/dashboard/templates/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = { darkMode: 'class' }
+    </script>
+    <title>Login</title>
+</head>
+<body class="bg-gray-900 text-gray-100 flex items-center justify-center h-screen">
+    <form method="post" class="bg-gray-800 p-6 rounded space-y-4">
+        {% if error %}<p class="text-red-400">{{ error }}</p>{% endif %}
+        <input type="password" name="token" placeholder="Token" class="w-full p-2 rounded bg-gray-700" />
+        <button type="submit" class="w-full bg-blue-600 hover:bg-blue-700 p-2 rounded">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create FastAPI `dashboard` package with `create_app` entry point
- add TailwindCSS dark-mode base template and navigation links
- implement token-based login and session protection

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a083bf8c20833390bc55bb968692cb