### PR TITLE
Add Tailwind dashboard with dark mode toggle

### DIFF
--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    if (localStorage.theme === 'light') {
+      document.documentElement.classList.remove('dark');
+    }
+  </script>
+  <title>Dashboard</title>
+</head>
+<body class="min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white transition-colors">
+  <header class="p-4 flex justify-between items-center">
+    <h1 class="text-2xl font-bold">Graal Dashboard</h1>
+    <button id="theme-toggle" class="px-4 py-2 rounded bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200">Toggle theme</button>
+  </header>
+  <main class="p-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-4 gap-4">
+    <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+      <h2 class="text-xl font-semibold mb-2">Shopify</h2>
+      <p>Widget Shopify</p>
+    </div>
+    <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+      <h2 class="text-xl font-semibold mb-2">Make</h2>
+      <p>Widget Make</p>
+    </div>
+    <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+      <h2 class="text-xl font-semibold mb-2">Runway</h2>
+      <p>Widget Runway</p>
+    </div>
+    <div class="p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+      <h2 class="text-xl font-semibold mb-2">Audio</h2>
+      <p>Widget Audio</p>
+    </div>
+  </main>
+  <script>
+    document.getElementById('theme-toggle').addEventListener('click', () => {
+      const html = document.documentElement;
+      if (html.classList.contains('dark')) {
+        html.classList.remove('dark');
+        localStorage.theme = 'light';
+      } else {
+        html.classList.add('dark');
+        localStorage.theme = 'dark';
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dashboard static page styled with Tailwind via CDN
- implement dark theme with toggleable light mode
- layout responsive grid with widget cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a083bc1600833397085b37da8a4cde