### PR TITLE
Add buttons for Make scenario and Runway video generation

### DIFF
--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -33,5 +33,17 @@ def install():
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
 
 
+@app.route("/make/trigger", methods=["POST"])
+def make_trigger():
+    """Endpoint pour déclencher un scénario Make (stub)."""
+    return {"status": "success", "message": "Scénario Make lancé"}
+
+
+@app.route("/runway/generate", methods=["POST"])
+def runway_generate():
+    """Endpoint pour générer une vidéo Runway (stub)."""
+    return {"status": "success", "message": "Génération de la vidéo Runway"}
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/support_assistant/templates/index.html
+++ b/support_assistant/templates/index.html
@@ -13,5 +13,42 @@
         <input type="text" id="scenario_id" name="scenario_id" required><br>
         <button type="submit">Installer</button>
     </form>
+
+    <div>
+        <button id="trigger-make">Lancer scénario Make</button>
+        <button id="generate-runway">Générer vidéo Runway</button>
+    </div>
+
+    <div id="notification" style="margin-top: 1em;"></div>
+
+    <script>
+        function showNotification(message, success) {
+            const note = document.getElementById('notification');
+            note.textContent = message;
+            note.style.color = success ? 'green' : 'red';
+        }
+
+        document.getElementById('trigger-make').addEventListener('click', async () => {
+            try {
+                const response = await fetch('/make/trigger', { method: 'POST' });
+                if (!response.ok) throw new Error('Erreur lors du lancement du scénario Make');
+                const data = await response.json();
+                showNotification(data.message || 'Succès', true);
+            } catch (err) {
+                showNotification(err.message, false);
+            }
+        });
+
+        document.getElementById('generate-runway').addEventListener('click', async () => {
+            try {
+                const response = await fetch('/runway/generate', { method: 'POST' });
+                if (!response.ok) throw new Error('Erreur lors de la génération de la vidéo Runway');
+                const data = await response.json();
+                showNotification(data.message || 'Succès', true);
+            } catch (err) {
+                showNotification(err.message, false);
+            }
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add stub endpoints for `/make/trigger` and `/runway/generate`
- Extend main template with buttons that POST to new endpoints and show success/error messages

## Testing
- `python -m py_compile support_assistant/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a083ba302883339aeb76211f7ca4f1