### PR TITLE
Add Shopify sales endpoints and streaming

### DIFF
--- a/dashboard/shopify.py
+++ b/dashboard/shopify.py
@@ -1,0 +1,26 @@
+import os
+import requests
+from typing import Dict, Any
+
+
+class ShopifyClient:
+    """Minimal Shopify Admin REST API client."""
+
+    def __init__(self, shop_name: str, access_token: str, api_version: str = "2023-07") -> None:
+        self.base_url = f"https://{shop_name}.myshopify.com/admin/api/{api_version}"
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "X-Shopify-Access-Token": access_token,
+                "Content-Type": "application/json",
+            }
+        )
+
+    def get_orders(self, status: str = "open", limit: int = 10) -> Dict[str, Any]:
+        """Fetch a batch of orders from Shopify."""
+        url = f"{self.base_url}/orders.json"
+        params = {"status": status, "limit": limit}
+        response = self.session.get(url, params=params)
+        if response.ok:
+            return response.json()
+        return {"error": response.text, "status_code": response.status_code}

--- a/support_assistant/app.py
+++ b/support_assistant/app.py
@@ -1,10 +1,25 @@
-from flask import Flask, request, render_template
+import os
+import sys
+import json
+import time
+
+from flask import Flask, request, render_template, jsonify, Response, stream_with_context
 import requests
+
+# Allow imports from parent directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from dashboard.shopify import ShopifyClient
 
 app = Flask(__name__)
 
 OWNER_EMAIL = "patrickgarnon09@gmail.com"
 MAKE_API_BASE = "https://api.make.com/v2"  # Placeholder base URL
+
+# Initialize Shopify client using environment variables as defaults
+shopify_client = ShopifyClient(
+    shop_name=os.environ.get("SHOPIFY_SHOP_NAME", "demo"),
+    access_token=os.environ.get("SHOPIFY_ACCESS_TOKEN", "demo"),
+)
 
 
 def connect_to_make(api_token: str, scenario_id: str) -> dict:
@@ -31,6 +46,36 @@ def install():
         return "Missing credentials", 400
     result = connect_to_make(api_token, scenario_id)
     return f"Scenario {result['scenario']} triggered with status {result['status']}."
+
+
+@app.route("/shopify/sales", methods=["GET"])
+def shopify_sales():
+    """Return a batch of Shopify sales."""
+    try:
+        orders = shopify_client.get_orders()
+        return jsonify(orders)
+    except Exception as exc:  # pragma: no cover - simple error propagation
+        return jsonify({"error": str(exc)}), 500
+
+
+def _sales_stream():
+    """Yield new sales as Server-Sent Events."""
+    seen = set()
+    while True:
+        orders = shopify_client.get_orders().get("orders", [])
+        for order in orders:
+            oid = order.get("id")
+            if oid not in seen:
+                seen.add(oid)
+                data = json.dumps(order)
+                yield f"data: {data}\n\n"
+        time.sleep(5)
+
+
+@app.route("/shopify/sales/stream")
+def stream_sales():
+    """Stream sales updates to the client using EventSource."""
+    return Response(stream_with_context(_sales_stream()), mimetype="text/event-stream")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add minimal Shopify REST client
- expose `/shopify/sales` endpoint
- stream new sales events via Server-Sent Events

## Testing
- `python -m py_compile support_assistant/app.py dashboard/shopify.py`


------
https://chatgpt.com/codex/tasks/task_e_68a083b5efa08333b1a817a0d2b66630