### PR TITLE
feat: add scenario autopilot

### DIFF
--- a/make_scenario_builder.py
+++ b/make_scenario_builder.py
@@ -1,5 +1,7 @@
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
 import requests
-from typing import Dict
 
 
 class MakeScenarioBuilder:
@@ -14,10 +16,13 @@ class MakeScenarioBuilder:
         """
         self.base_url = base_url.rstrip('/')
         self.session = requests.Session()
-        self.session.headers.update({
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        })
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            }
+        )
+        self.logger = logging.getLogger(self.__class__.__name__)
 
     def create_scenario(self, structure: Dict) -> str:
         """Create a new scenario from the given structure.
@@ -79,21 +84,75 @@ class MakeScenarioBuilder:
         except requests.RequestException as exc:  # pragma: no cover - network dependency
             return f"Error modifying scenario: {exc}"  # pragma: no cover
 
-    def run_scenario(self, scenario_id: str) -> str:
-        """Trigger execution of the specified scenario.
+    def run_scenario(self, scenario_id: str) -> Dict:
+        """Trigger execution of the specified scenario and return its result.
 
         Args:
             scenario_id: Identifier of the scenario to run.
 
         Returns:
-            A success or error message.
+            Parsed JSON response from the API or an error dictionary.
         """
         url = f"{self.base_url}/v2/scenarios/{scenario_id}/run"
         try:
             response = self.session.post(url)
             response.raise_for_status()
-            return "Scenario run triggered"
+            return response.json()
         except requests.HTTPError as exc:  # pragma: no cover - network dependency
-            return f"Error running scenario: {exc.response.text if exc.response else exc}"  # pragma: no cover
+            return {"error": f"Error running scenario: {exc.response.text if exc.response else exc}"}  # pragma: no cover
         except requests.RequestException as exc:  # pragma: no cover - network dependency
-            return f"Error running scenario: {exc}"  # pragma: no cover
+            return {"error": f"Error running scenario: {exc}"}  # pragma: no cover
+
+    def auto_pilot(
+        self,
+        scenario_id: str,
+        metrics_fn: Callable[[Dict[str, Any]], float],
+        *,
+        threshold: float = 1.0,
+        max_iterations: int = 5,
+        adjustments: Optional[
+            List[Callable[[str, float, Dict[str, Any]], Optional[Dict[str, Any]]]]
+        ] = None,
+    ) -> List[Dict[str, Any]]:
+        """Run a scenario repeatedly, tuning it based on metrics.
+
+        The scenario is executed and evaluated with ``metrics_fn``.  If the
+        resulting metric is below ``threshold`` and adjustment strategies are
+        provided, each strategy may return a patch to apply via
+        :meth:`modify_scenario`.  Execution stops once the threshold is met or
+        ``max_iterations`` is reached.
+
+        Returns a history list containing the metric and raw result for each
+        iteration, which is useful for auditing and debugging.
+        """
+
+        history: List[Dict[str, Any]] = []
+        for iteration in range(1, max_iterations + 1):
+            self.logger.info("Starting iteration %s for scenario %s", iteration, scenario_id)
+            result = self.run_scenario(scenario_id)
+            metric = metrics_fn(result)
+            self.logger.info("Iteration %s metric: %s", iteration, metric)
+            history.append(
+                {
+                    "iteration": iteration,
+                    "scenario_id": scenario_id,
+                    "metric": metric,
+                    "result": result,
+                }
+            )
+            if metric >= threshold:
+                self.logger.info(
+                    "Threshold %.2f reached with metric %.2f; stopping.", threshold, metric
+                )
+                break
+            if adjustments:
+                for strategy in adjustments:
+                    patch = strategy(scenario_id, metric, result)
+                    if patch:
+                        self.logger.debug(
+                            "Applying adjustment via %s: %s",
+                            getattr(strategy, "__name__", str(strategy)),
+                            patch,
+                        )
+                        self.modify_scenario(scenario_id, patch)
+        return history

--- a/tests/test_auto_pilot_method.py
+++ b/tests/test_auto_pilot_method.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from unittest.mock import MagicMock
+
+from make_scenario_builder import MakeScenarioBuilder
+
+
+def test_auto_pilot_iterates_and_applies_adjustments():
+    builder = MakeScenarioBuilder("token", "https://api.make.com")
+    builder.run_scenario = MagicMock(side_effect=[{"score": 0.2}, {"score": 1.3}])
+    builder.modify_scenario = MagicMock(return_value="ok")
+
+    def metrics_fn(result):
+        return result["score"]
+
+    def adjustment(scenario_id, metric, result):
+        return {"tuned": metric}
+
+    history = builder.auto_pilot(
+        "42",
+        metrics_fn,
+        threshold=1.0,
+        max_iterations=5,
+        adjustments=[adjustment],
+    )
+
+    assert builder.run_scenario.call_count == 2
+    builder.modify_scenario.assert_called_once_with("42", {"tuned": 0.2})
+    assert len(history) == 2
+    assert history[-1]["metric"] >= 1.0


### PR DESCRIPTION
## Summary
- extend MakeScenarioBuilder with `auto_pilot` for iterative scenario tuning
- return API results from `run_scenario`
- add tests for autopilot loop and adjustments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3360e0b808333b8eb926226a9b3be